### PR TITLE
Enable all ignored Vyper tests for >=0.3.9

### DIFF
--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -14,6 +14,5 @@
 <!-- Check your PR fulfills the following items. -->
 <!-- For draft PRs check the boxes as you complete them. -->
 
-- [ ] PR title corresponds to the body of PR (we generate changelog entries from PRs).
-- [ ] Tests for the changes have been added / updated.
+- [ ] PR title corresponds to the body of PR.
 - [ ] Documentation comments have been added / updated.

--- a/vyper/complex/external/arithmetics/check_var_init/test.json
+++ b/vyper/complex/external/arithmetics/check_var_init/test.json
@@ -1,4 +1,4 @@
-{ "ignore": true, "cases": [ {
+{ "modes": [ ">=0.3.9" ], "cases": [ {
     "name": "default",
     "inputs": [
         {

--- a/vyper/complex/external/array/copying/copying_bytes_multiassign/test.json
+++ b/vyper/complex/external/array/copying/copying_bytes_multiassign/test.json
@@ -1,4 +1,4 @@
-{ "ignore": true, "cases": [ {
+{ "modes": [ ">=0.3.9" ], "cases": [ {
     "name": "default",
     "inputs": [
         {

--- a/vyper/complex/external/array/fixed_arrays_as_return_type/test.json
+++ b/vyper/complex/external/array/fixed_arrays_as_return_type/test.json
@@ -1,4 +1,4 @@
-{ "ignore": true, "cases": [ {
+{ "modes": [ ">=0.3.9" ], "cases": [ {
     "name": "default",
     "inputs": [
         {

--- a/vyper/complex/external/array/reusing_memory/test.json
+++ b/vyper/complex/external/array/reusing_memory/test.json
@@ -1,4 +1,4 @@
-{ "ignore": true, "cases": [ {
+{ "modes": [ ">=0.3.9" ], "cases": [ {
     "name": "default",
     "inputs": [
         {

--- a/vyper/complex/external/constructor/arrays_in_constructors/test.json
+++ b/vyper/complex/external/constructor/arrays_in_constructors/test.json
@@ -1,4 +1,4 @@
-{ "ignore": true, "cases": [ {
+{ "modes": [ ">=0.3.9" ], "cases": [ {
     "name": "default",
     "inputs": [
         {

--- a/vyper/complex/external/constructor/bytes_in_constructors_packer/test.json
+++ b/vyper/complex/external/constructor/bytes_in_constructors_packer/test.json
@@ -1,4 +1,4 @@
-{ "ignore": true, "cases": [ {
+{ "modes": [ ">=0.3.9" ], "cases": [ {
     "name": "default",
     "inputs": [
         {

--- a/vyper/complex/external/fallback/call_forward_bytes/test.json
+++ b/vyper/complex/external/fallback/call_forward_bytes/test.json
@@ -1,4 +1,4 @@
-{ "ignore": true, "cases": [ {
+{ "modes": [ ">=0.3.9" ], "cases": [ {
     "name": "default",
     "inputs": [
         {

--- a/vyper/complex/external/functionCall/creation_function_call_no_args/test.json
+++ b/vyper/complex/external/functionCall/creation_function_call_no_args/test.json
@@ -1,4 +1,4 @@
-{ "ignore": true, "cases": [ {
+{ "modes": [ ">=0.3.9" ], "cases": [ {
     "name": "default",
     "inputs": [
         {

--- a/vyper/complex/external/functionCall/creation_function_call_with_args/test.json
+++ b/vyper/complex/external/functionCall/creation_function_call_with_args/test.json
@@ -1,4 +1,4 @@
-{ "ignore": true, "cases": [ {
+{ "modes": [ ">=0.3.9" ], "cases": [ {
     "name": "default",
     "inputs": [
         {

--- a/vyper/complex/external/functionCall/creation_function_call_with_salt/test.json
+++ b/vyper/complex/external/functionCall/creation_function_call_with_salt/test.json
@@ -1,4 +1,4 @@
-{ "ignore": true, "cases": [ {
+{ "modes": [ ">=0.3.9" ], "cases": [ {
     "name": "default",
     "inputs": [
         {

--- a/vyper/complex/external/structs/copy_from_calldata/test.json
+++ b/vyper/complex/external/structs/copy_from_calldata/test.json
@@ -1,4 +1,4 @@
-{ "ignore": true, "cases": [ {
+{ "modes": [ ">=0.3.9" ], "cases": [ {
     "name": "default",
     "inputs": [
         {

--- a/vyper/complex/external/various/external_types_in_calls/test.json
+++ b/vyper/complex/external/various/external_types_in_calls/test.json
@@ -1,4 +1,4 @@
-{ "ignore": true, "cases": [ {
+{ "modes": [ ">=0.3.9" ], "cases": [ {
     "name": "default",
     "inputs": [
         {

--- a/vyper/complex/external/various/write_storage_external/test.json
+++ b/vyper/complex/external/various/write_storage_external/test.json
@@ -1,4 +1,4 @@
-{ "ignore": true, "cases": [ {
+{ "modes": [ ">=0.3.9" ], "cases": [ {
     "name": "default",
     "inputs": [
         {

--- a/vyper/complex/solidity_by_example/simple/import/test.json
+++ b/vyper/complex/solidity_by_example/simple/import/test.json
@@ -1,4 +1,4 @@
-{ "ignore": true, "cases": [ {
+{ "modes": [ ">=0.3.9" ], "cases": [ {
     "name": "entry",
     "inputs": [
         {

--- a/vyper/ethereum/index.yaml
+++ b/vyper/ethereum/index.yaml
@@ -45,8 +45,9 @@ entries:
       memory_params_in_external_function.vy:
         enabled: true
       return_dynamic_types_cross_call_advanced.vy:
-        enabled: false
-        comment: "https://linear.app/matterlabs/issue/CPR-722/vyper-problems"
+        enabled: true
+        modes:
+        - '>=0.3.9'
       return_dynamic_types_cross_call_simple.vy:
         enabled: true
       struct:
@@ -71,33 +72,40 @@ entries:
       byte_arrays.vy:
         enabled: true
       calldata_array.vy:
-        enabled: false
-        comment: "https://linear.app/matterlabs/issue/CPR-722/vyper-problems"
+        enabled: true
+        modes:
+        - '>=0.3.9'
       calldata_array_dynamic.vy:
         enabled: true
       calldata_array_dynamic_index_access.vy:
-        enabled: false
-        comment: "https://linear.app/matterlabs/issue/CPR-722/vyper-problems"
+        enabled: true
+        modes:
+        - '>=0.3.9'
       calldata_array_dynamic_static_dynamic.vy:
-        enabled: false
-        comment: "https://linear.app/matterlabs/issue/CPR-722/vyper-problems"
+        enabled: true
+        modes:
+        - '>=0.3.9'
       calldata_array_dynamic_static_short_decode.vy:
-        enabled: false
-        comment: "https://linear.app/matterlabs/issue/CPR-722/vyper-problems"
+        enabled: true
+        modes:
+        - '>=0.3.9'
       calldata_array_dynamic_static_short_reencode.vy:
-        enabled: false
-        comment: "https://linear.app/matterlabs/issue/CPR-722/vyper-problems"
+        enabled: true
+        modes:
+        - '>=0.3.9'
       calldata_array_multi_dynamic.vy:
-        enabled: false
-        comment: "https://linear.app/matterlabs/issue/CPR-722/vyper-problems"
+        enabled: true
+        modes:
+        - '>=0.3.9'
       calldata_array_short_no_revert_string.vy:
         enabled: false
         comment: "Other behavior on EraVM"
       calldata_array_static.vy:
         enabled: true
       calldata_array_static_dynamic_static.vy:
-        enabled: false
-        comment: "https://linear.app/matterlabs/issue/CPR-722/vyper-problems"
+        enabled: true
+        modes:
+        - '>=0.3.9'
       calldata_array_static_index_access.vy:
         enabled: true
       calldata_array_struct_dynamic.vy:
@@ -110,8 +118,9 @@ entries:
         enabled: false
         comment: "Other behavior on EraVM"
       calldata_nested_array_static_reencode.vy:
-        enabled: false
-        comment: "https://linear.app/matterlabs/issue/CPR-722/vyper-problems"
+        enabled: true
+        modes:
+        - '>=0.3.9'
       calldata_struct_dynamic.vy:
         enabled: true
       calldata_struct_member_offset.vy:
@@ -142,8 +151,9 @@ entries:
       dynamic_arrays.vy:
         enabled: true
       dynamic_nested_arrays.vy:
-        enabled: false
-        comment: "https://linear.app/matterlabs/issue/CPR-722/vyper-problems"
+        enabled: true
+        modes:
+        - '>=0.3.9'
       memory_params_in_external_function.vy:
         enabled: true
       storage_array_encoding.vy:
@@ -202,8 +212,9 @@ entries:
         enabled: false
         comment: "Other behavior on EraVM"
       calldata_array_dynamic_invalid_static_middle.vy:
-        enabled: false
-        comment: "https://linear.app/matterlabs/issue/CPR-722/vyper-problems"
+        enabled: true
+        modes:
+        - '>=0.3.9'
       calldata_array_of_struct.vy:
         enabled: true
       calldata_array_two_dimensional.vy:
@@ -256,8 +267,9 @@ entries:
           array_copy_storage_storage_dynamic_dynamic.vy:
             enabled: true
           array_copy_storage_storage_static_dynamic.vy:
-            enabled: false
-            comment: "https://linear.app/matterlabs/issue/CPR-722/vyper-problems"
+            enabled: true
+            modes:
+            - '>=0.3.9'
           array_copy_storage_storage_static_simple.vy:
             enabled: true
           array_copy_storage_storage_static_static.vy:
@@ -316,13 +328,15 @@ entries:
           calldata_bytes_to_storage.vy:
             enabled: true
           calldata_dyn_2d_bytes_to_memory.vy:
-            enabled: false
-            comment: "https://linear.app/matterlabs/issue/CPR-722/vyper-problems"
+            enabled: true
+            modes:
+            - '>=0.3.9'
           calldata_dynamic_array_to_memory.vy:
             enabled: true
           calldata_nested_array_copy_to_memory.vy:
-            enabled: false
-            comment: "https://linear.app/matterlabs/issue/CPR-722/vyper-problems"
+            enabled: true
+            modes:
+            - '>=0.3.9'
           cleanup_during_multi_element_per_slot_copy.vy:
             enabled: true
           copy_byte_array_in_struct_to_storage.vy:
@@ -334,8 +348,9 @@ entries:
           empty_bytes_copy.vy:
             enabled: true
           memory_dyn_2d_bytes_to_storage.vy:
-            enabled: false
-            comment: "https://linear.app/matterlabs/issue/CPR-722/vyper-problems"
+            enabled: true
+            modes:
+            - '>=0.3.9'
           storage_memory_nested.vy:
             enabled: true
           storage_memory_nested_bytes.vy:
@@ -411,10 +426,13 @@ entries:
           inline_array_index_access_strings.vy:
             enabled: true
           memory_arrays_dynamic_index_access_write.vy:
-            enabled: false
-            comment: "https://linear.app/matterlabs/issue/CPR-722/vyper-problems"
+            enabled: true
+            modes:
+            - '>=0.3.9'
           memory_arrays_index_access_write.vy:
-            enabled: false
+            enabled: true
+            modes:
+            - '>=0.3.9'
       inline_array_return.vy:
         enabled: true
       inline_array_singleton.vy:
@@ -536,8 +554,9 @@ entries:
       calldata_bytes_to_memory_encode.vy:
         enabled: true
       calldata_internal_multi_array.vy:
-        enabled: false
-        comment: "https://linear.app/matterlabs/issue/CPR-722/vyper-problems"
+        enabled: true
+        modes:
+        - '>=0.3.9'
       calldata_internal_multi_fixed_array.vy:
         enabled: true
       calldata_memory_mixed.vy:
@@ -592,8 +611,9 @@ entries:
       constructor_static_array_argument.vy:
         enabled: true
       functions_called_by_constructor.vy:
-        enabled: false
-        comment: "https://github.com/vyperlang/vyper/issues/1631"
+        enabled: true
+        modes:
+        - '>=0.3.9'
       payable_constructor.vy:
         enabled: true
   constructor_with_params.vy:
@@ -623,8 +643,9 @@ entries:
         enabled: false
         comment: "The input is considered invalid"
   empty_contract.vy:
-    enabled: false
-    comment: "https://github.com/vyperlang/vyper/issues/2803"
+    enabled: true
+    modes:
+    - '>=0.3.9'
   events:
     enabled: true
     entries:
@@ -637,8 +658,9 @@ entries:
       event_dynamic_array_storage.vy:
         enabled: true
       event_dynamic_nested_array_memory_v2.vy:
-        enabled: false
-        comment: "https://linear.app/matterlabs/issue/CPR-722/vyper-problems"
+        enabled: true
+        modes:
+        - '>=0.3.9'
       event_dynamic_nested_array_storage_v2.vy:
         enabled: true
       event_emit.vy:
@@ -755,8 +777,9 @@ entries:
       assign_from_immutables.vy:
         enabled: true
       fun_read_in_ctor.vy:
-        enabled: false
-        comment: "https://github.com/vyperlang/vyper/issues/1631"
+        enabled: true
+        modes:
+        - '>=0.3.9'
       immutable_signed.vy:
         enabled: true
       read_in_ctor.vy:
@@ -890,11 +913,13 @@ entries:
         enabled: false
         comment: "Other behavior on EraVM"
       calldata_array_dynamic_static_short_decode.vy:
-        enabled: false
-        comment: "https://linear.app/matterlabs/issue/CPR-722/vyper-problems"
+        enabled: true
+        modes:
+        - '>=0.3.9'
       calldata_array_dynamic_static_short_reencode.vy:
-        enabled: false
-        comment: "https://linear.app/matterlabs/issue/CPR-722/vyper-problems"
+        enabled: true
+        modes:
+        - '>=0.3.9'
       calldata_array_invalid_length.vy:
         enabled: false
         comment: "Other behavior on EraVM"
@@ -982,11 +1007,13 @@ entries:
       mapping_string_key.vy:
         enabled: true
       mappings_array2d_pop_delete.vy:
-        enabled: false
-        comment: "https://linear.app/matterlabs/issue/CPR-722/vyper-problems"
+        enabled: true
+        modes:
+        - '>=0.3.9'
       mappings_array_pop_delete.vy:
-        enabled: false
-        comment: "https://linear.app/matterlabs/issue/CPR-722/vyper-problems"
+        enabled: true
+        modes:
+        - '>=0.3.9'
       packed_storage_signed.vy:
         enabled: true
       packed_storage_structs_bytes.vy:
@@ -1037,8 +1064,9 @@ entries:
     enabled: true
     entries:
       array_of_recursive_struct.vy:
-        enabled: false
-        comment: "https://linear.app/matterlabs/issue/CPR-722/vyper-problems"
+        enabled: true
+        modes:
+        - '>=0.3.9'
       calldata:
         enabled: true
         entries:
@@ -1053,8 +1081,9 @@ entries:
           calldata_struct_array_member_dynamic.vy:
             enabled: true
           calldata_struct_as_memory_argument.vy:
-            enabled: false
-            comment: "https://github.com/vyperlang/vyper/issues/2800"
+            enabled: true
+            modes:
+            - '>=0.3.9'
           calldata_struct_struct_member.vy:
             enabled: true
           calldata_struct_struct_member_dynamic.vy:
@@ -1068,8 +1097,9 @@ entries:
           calldata_struct_with_bytes_to_memory.vy:
             enabled: true
           calldata_struct_with_nested_array_to_memory.vy:
-            enabled: false
-            comment: "https://github.com/vyperlang/vyper/issues/2800"
+            enabled: true
+            modes:
+            - '>=0.3.9'
           calldata_struct_with_nested_array_to_storage.vy:
             enabled: true
           calldata_structs.vy:
@@ -1082,16 +1112,19 @@ entries:
         enabled: true
         entries:
           recursive_storage_memory.vy:
-            enabled: false
-            comment: "https://linear.app/matterlabs/issue/CPR-722/vyper-problems"
+            enabled: true
+            modes:
+            - '>=0.3.9'
           recursive_storage_memory_complex.vy:
-            enabled: false
-            comment: "https://linear.app/matterlabs/issue/CPR-722/vyper-problems"
+            enabled: true
+            modes:
+            - '>=0.3.9'
       copy_from_storage.vy:
         enabled: true
       copy_struct_array_from_storage.vy:
-        enabled: false
-        comment: "https://linear.app/matterlabs/issue/CPR-722/vyper-problems"
+        enabled: true
+        modes:
+        - '>=0.3.9'
       delete_struct.vy:
         enabled: true
       event.vy:
@@ -1120,8 +1153,9 @@ entries:
       packed_storage_structs_delete.vy:
         enabled: true
       recursive_structs.vy:
-        enabled: false
-        comment: "https://linear.app/matterlabs/issue/CPR-722/vyper-problems"
+        enabled: true
+        modes:
+        - '>=0.3.9'
       simple_struct_allocation.vy:
         enabled: true
       struct_constructor_nested.vy:
@@ -1138,13 +1172,15 @@ entries:
       struct_delete_storage.vy:
         enabled: true
       struct_delete_storage_nested_small.vy:
-        enabled: false
-        comment: "https://linear.app/matterlabs/issue/CPR-722/vyper-problems"
+        enabled: true
+        modes:
+        - '>=0.3.9'
       struct_delete_storage_small.vy:
         enabled: true
       struct_delete_storage_with_array.vy:
-        enabled: false
-        comment: "https://github.com/vyperlang/vyper/issues/2801"
+        enabled: true
+        modes:
+        - '>=0.3.9'
       struct_delete_storage_with_arrays_small.vy:
         enabled: true
       struct_delete_struct_in_mapping.vy:
@@ -1161,8 +1197,9 @@ entries:
       struct_storage_to_memory.vy:
         enabled: true
       structs.vy:
-        enabled: false
-        comment: "https://linear.app/matterlabs/issue/CPR-722/vyper-problems"
+        enabled: true
+        modes:
+        - '>=0.3.9'
   types:
     enabled: true
     entries:
@@ -1227,8 +1264,9 @@ entries:
       empty_name_return_parameter.vy:
         enabled: true
       erc20.vy:
-        enabled: false
-        comment: "https://github.com/vyperlang/vyper/issues/1631"
+        enabled: true
+        modes:
+        - '>=0.3.9'
       flipping_sign_tests.vy:
         enabled: true
       gasleft_decrease.vy:
@@ -1254,11 +1292,13 @@ entries:
       skip_dynamic_types.vy:
         enabled: true
       skip_dynamic_types_for_static_arrays_with_dynamic_elements.vy:
-        enabled: false
-        comment: "https://linear.app/matterlabs/issue/CPR-722/vyper-problems"
+        enabled: true
+        modes:
+        - '>=0.3.9'
       skip_dynamic_types_for_structs.vy:
-        enabled: false
-        comment: "https://linear.app/matterlabs/issue/CPR-722/vyper-problems"
+        enabled: true
+        modes:
+        - '>=0.3.9'
       state_variable_local_variable_mixture.vy:
         enabled: true
       storage_string_as_mapping_key_without_variable.vy:
@@ -1419,8 +1459,9 @@ entries:
       simple_assignment.vy:
         enabled: true
       smoke_test.vy:
-        enabled: false
-        comment: "https://github.com/vyperlang/vyper/issues/2803"
+        enabled: true
+        modes:
+        - '>=0.3.9'
       storage:
         enabled: true
         entries:

--- a/vyper/simple/algorithm/split.vy
+++ b/vyper/simple/algorithm/split.vy
@@ -1,4 +1,4 @@
-#! { "ignore": true, "cases": [ {
+#! { "modes": [ ">=0.3.9" ], "cases": [ {
 #!     "name": "default",
 #!     "inputs": [
 #!         {

--- a/vyper/simple/constructor/call_public.vy
+++ b/vyper/simple/constructor/call_public.vy
@@ -1,4 +1,4 @@
-#! { "ignore": true, "cases": [ {
+#! { "modes": [ ">=0.3.9" ], "cases": [ {
 #!     "name": "success",
 #!     "inputs": [
 #!         {

--- a/vyper/simple/function/simple_types.vy
+++ b/vyper/simple/function/simple_types.vy
@@ -1,4 +1,4 @@
-#! { "ignore": true, "cases": [ {
+#! { "modes": [ ">=0.3.9" ], "cases": [ {
 #!     "name": "_default",
 #!     "inputs": [
 #!         {

--- a/vyper/simple/loop/range_bitlength_inference/i8_to_i16.vy
+++ b/vyper/simple/loop/range_bitlength_inference/i8_to_i16.vy
@@ -1,4 +1,4 @@
-#! { "ignore": true, "cases": [ {
+#! { "modes": [ ">=0.3.9" ], "cases": [ {
 #!     "name": "main",
 #!     "inputs": [
 #!         {

--- a/vyper/simple/loop/range_bitlength_inference/u16_to_i16.vy
+++ b/vyper/simple/loop/range_bitlength_inference/u16_to_i16.vy
@@ -1,4 +1,4 @@
-#! { "ignore": true, "cases": [ {
+#! { "modes": [ ">=0.3.9" ], "cases": [ {
 #!     "name": "main",
 #!     "inputs": [
 #!         {

--- a/vyper/simple/loop/range_bitlength_inference/u8_to_i8.vy
+++ b/vyper/simple/loop/range_bitlength_inference/u8_to_i8.vy
@@ -1,4 +1,4 @@
-#! { "ignore": true, "cases": [ {
+#! { "modes": [ ">=0.3.9" ], "cases": [ {
 #!     "name": "main",
 #!     "inputs": [
 #!         {

--- a/vyper/simple/loop/range_bitlength_inference/u8_to_u16.vy
+++ b/vyper/simple/loop/range_bitlength_inference/u8_to_u16.vy
@@ -1,4 +1,4 @@
-#! { "ignore": true, "cases": [ {
+#! { "modes": [ ">=0.3.9" ], "cases": [ {
 #!     "name": "main",
 #!     "inputs": [
 #!         {

--- a/vyper/simple/loop/range_bitlength_inference/u8_to_u64_const.vy
+++ b/vyper/simple/loop/range_bitlength_inference/u8_to_u64_const.vy
@@ -1,4 +1,4 @@
-#! { "ignore": true, "cases": [ {
+#! { "modes": [ ">=0.3.9" ], "cases": [ {
 #!     "name": "main",
 #!     "inputs": [
 #!         {

--- a/vyper/simple/loop/range_bound/i16.vy
+++ b/vyper/simple/loop/range_bound/i16.vy
@@ -1,4 +1,4 @@
-#! { "ignore": true, "cases": [ {
+#! { "modes": [ ">=0.3.9" ], "cases": [ {
 #!     "name": "main",
 #!     "inputs": [
 #!         {

--- a/vyper/simple/loop/range_bound/i32_lower.vy
+++ b/vyper/simple/loop/range_bound/i32_lower.vy
@@ -1,4 +1,4 @@
-#! { "ignore": true, "cases": [ {
+#! { "modes": [ ">=0.3.9" ], "cases": [ {
 #!     "name": "main",
 #!     "inputs": [
 #!         {

--- a/vyper/simple/loop/range_bound/i32_upper.vy
+++ b/vyper/simple/loop/range_bound/i32_upper.vy
@@ -1,4 +1,4 @@
-#! { "ignore": true, "cases": [ {
+#! { "modes": [ ">=0.3.9" ], "cases": [ {
 #!     "name": "main",
 #!     "inputs": [
 #!         {

--- a/vyper/simple/loop/range_bound/i64_lower.vy
+++ b/vyper/simple/loop/range_bound/i64_lower.vy
@@ -1,4 +1,4 @@
-#! { "ignore": true, "cases": [ {
+#! { "modes": [ ">=0.3.9" ], "cases": [ {
 #!     "name": "main",
 #!     "inputs": [
 #!         {

--- a/vyper/simple/loop/range_bound/i64_upper.vy
+++ b/vyper/simple/loop/range_bound/i64_upper.vy
@@ -1,4 +1,4 @@
-#! { "ignore": true, "cases": [ {
+#! { "modes": [ ">=0.3.9" ], "cases": [ {
 #!     "name": "main",
 #!     "inputs": [
 #!         {

--- a/vyper/simple/loop/range_bound/i8.vy
+++ b/vyper/simple/loop/range_bound/i8.vy
@@ -1,4 +1,4 @@
-#! { "ignore": true, "cases": [ {
+#! { "modes": [ ">=0.3.9" ], "cases": [ {
 #!     "name": "main",
 #!     "inputs": [
 #!         {

--- a/vyper/simple/loop/range_bound/u16.vy
+++ b/vyper/simple/loop/range_bound/u16.vy
@@ -1,4 +1,4 @@
-#! { "ignore": true, "cases": [ {
+#! { "modes": [ ">=0.3.9" ], "cases": [ {
 #!     "name": "main",
 #!     "inputs": [
 #!         {

--- a/vyper/simple/loop/range_bound/u32.vy
+++ b/vyper/simple/loop/range_bound/u32.vy
@@ -1,4 +1,4 @@
-#! { "ignore": true, "cases": [ {
+#! { "modes": [ ">=0.3.9" ], "cases": [ {
 #!     "name": "main",
 #!     "inputs": [
 #!         {

--- a/vyper/simple/loop/range_bound/u64.vy
+++ b/vyper/simple/loop/range_bound/u64.vy
@@ -1,4 +1,4 @@
-#! { "ignore": true, "cases": [ {
+#! { "modes": [ ">=0.3.9" ], "cases": [ {
 #!     "name": "main",
 #!     "inputs": [
 #!         {

--- a/vyper/simple/loop/range_bound/u8.vy
+++ b/vyper/simple/loop/range_bound/u8.vy
@@ -1,4 +1,4 @@
-#! { "ignore": true, "cases": [ {
+#! { "modes": [ ">=0.3.9" ], "cases": [ {
 #!     "name": "main",
 #!     "inputs": [
 #!         {

--- a/vyper/simple/operator/arithmetic/addition_i8.vy
+++ b/vyper/simple/operator/arithmetic/addition_i8.vy
@@ -1,4 +1,4 @@
-#! { "ignore": true, "cases": [ {
+#! { "modes": [ ">=0.3.9" ], "cases": [ {
 #!     "name": "zero_zero",
 #!     "inputs": [
 #!         {

--- a/vyper/simple/operator/arithmetic/division_i8.vy
+++ b/vyper/simple/operator/arithmetic/division_i8.vy
@@ -1,4 +1,4 @@
-#! { "ignore": true, "cases": [ {
+#! { "modes": [ ">=0.3.9" ], "cases": [ {
 #!     "name": "zero_by_zero",
 #!     "inputs": [
 #!         {

--- a/vyper/simple/operator/arithmetic/multiplication_i8.vy
+++ b/vyper/simple/operator/arithmetic/multiplication_i8.vy
@@ -1,4 +1,4 @@
-#! { "ignore": true, "cases": [ {
+#! { "modes": [ ">=0.3.9" ], "cases": [ {
 #!     "name": "zero_zero",
 #!     "inputs": [
 #!         {

--- a/vyper/simple/operator/arithmetic/subtraction_i8.vy
+++ b/vyper/simple/operator/arithmetic/subtraction_i8.vy
@@ -1,4 +1,4 @@
-#! { "ignore": true, "cases": [ {
+#! { "modes": [ ">=0.3.9" ], "cases": [ {
 #!     "name": "zero_zero",
 #!     "inputs": [
 #!         {

--- a/vyper/simple/operator/assignment/addition_i8.vy
+++ b/vyper/simple/operator/assignment/addition_i8.vy
@@ -1,4 +1,4 @@
-#! { "ignore": true, "cases": [ {
+#! { "modes": [ ">=0.3.9" ], "cases": [ {
 #!     "name": "zero_zero",
 #!     "inputs": [
 #!         {

--- a/vyper/simple/operator/assignment/division_i8.vy
+++ b/vyper/simple/operator/assignment/division_i8.vy
@@ -1,4 +1,4 @@
-#! { "ignore": true, "cases": [ {
+#! { "modes": [ ">=0.3.9" ], "cases": [ {
 #!     "name": "zero_by_zero",
 #!     "inputs": [
 #!         {

--- a/vyper/simple/operator/assignment/multiplication_i8.vy
+++ b/vyper/simple/operator/assignment/multiplication_i8.vy
@@ -1,4 +1,4 @@
-#! { "ignore": true, "cases": [ {
+#! { "modes": [ ">=0.3.9" ], "cases": [ {
 #!     "name": "zero_zero",
 #!     "inputs": [
 #!         {

--- a/vyper/simple/operator/assignment/subtraction_i8.vy
+++ b/vyper/simple/operator/assignment/subtraction_i8.vy
@@ -1,4 +1,4 @@
-#! { "ignore": true, "cases": [ {
+#! { "modes": [ ">=0.3.9" ], "cases": [ {
 #!     "name": "zero_zero",
 #!     "inputs": [
 #!         {

--- a/vyper/simple/overflow/negative/i16.vy
+++ b/vyper/simple/overflow/negative/i16.vy
@@ -1,4 +1,4 @@
-#! { "ignore": true, "cases": [ {
+#! { "modes": [ ">=0.3.9" ], "cases": [ {
 #!     "name": "default",
 #!     "inputs": [
 #!         {

--- a/vyper/simple/overflow/negative/i248.vy
+++ b/vyper/simple/overflow/negative/i248.vy
@@ -1,4 +1,4 @@
-#! { "ignore": true, "cases": [ {
+#! { "modes": [ ">=0.3.9" ], "cases": [ {
 #!     "name": "default",
 #!     "inputs": [
 #!         {

--- a/vyper/simple/overflow/negative/i32.vy
+++ b/vyper/simple/overflow/negative/i32.vy
@@ -1,4 +1,4 @@
-#! { "ignore": true, "cases": [ {
+#! { "modes": [ ">=0.3.9" ], "cases": [ {
 #!     "name": "default",
 #!     "inputs": [
 #!         {

--- a/vyper/simple/overflow/negative/i64.vy
+++ b/vyper/simple/overflow/negative/i64.vy
@@ -1,4 +1,4 @@
-#! { "ignore": true, "cases": [ {
+#! { "modes": [ ">=0.3.9" ], "cases": [ {
 #!     "name": "default",
 #!     "inputs": [
 #!         {

--- a/vyper/simple/overflow/negative/i8.vy
+++ b/vyper/simple/overflow/negative/i8.vy
@@ -1,4 +1,4 @@
-#! { "ignore": true, "cases": [ {
+#! { "modes": [ ">=0.3.9" ], "cases": [ {
 #!     "name": "default",
 #!     "inputs": [
 #!         {

--- a/vyper/simple/overflow/negative/u16.vy
+++ b/vyper/simple/overflow/negative/u16.vy
@@ -1,4 +1,4 @@
-#! { "ignore": true, "cases": [ {
+#! { "modes": [ ">=0.3.9" ], "cases": [ {
 #!     "name": "default",
 #!     "inputs": [
 #!         {

--- a/vyper/simple/overflow/negative/u248.vy
+++ b/vyper/simple/overflow/negative/u248.vy
@@ -1,4 +1,4 @@
-#! { "ignore": true, "cases": [ {
+#! { "modes": [ ">=0.3.9" ], "cases": [ {
 #!     "name": "default",
 #!     "inputs": [
 #!         {

--- a/vyper/simple/overflow/negative/u32.vy
+++ b/vyper/simple/overflow/negative/u32.vy
@@ -1,4 +1,4 @@
-#! { "ignore": true, "cases": [ {
+#! { "modes": [ ">=0.3.9" ], "cases": [ {
 #!     "name": "default",
 #!     "inputs": [
 #!         {

--- a/vyper/simple/overflow/negative/u64.vy
+++ b/vyper/simple/overflow/negative/u64.vy
@@ -1,4 +1,4 @@
-#! { "ignore": true, "cases": [ {
+#! { "modes": [ ">=0.3.9" ], "cases": [ {
 #!     "name": "default",
 #!     "inputs": [
 #!         {

--- a/vyper/simple/overflow/positive/i16.vy
+++ b/vyper/simple/overflow/positive/i16.vy
@@ -1,4 +1,4 @@
-#! { "ignore": true, "cases": [ {
+#! { "modes": [ ">=0.3.9" ], "cases": [ {
 #!     "name": "default",
 #!     "inputs": [
 #!         {

--- a/vyper/simple/overflow/positive/i248.vy
+++ b/vyper/simple/overflow/positive/i248.vy
@@ -1,4 +1,4 @@
-#! { "ignore": true, "cases": [ {
+#! { "modes": [ ">=0.3.9" ], "cases": [ {
 #!     "name": "default",
 #!     "inputs": [
 #!         {

--- a/vyper/simple/overflow/positive/i32.vy
+++ b/vyper/simple/overflow/positive/i32.vy
@@ -1,4 +1,4 @@
-#! { "ignore": true, "cases": [ {
+#! { "modes": [ ">=0.3.9" ], "cases": [ {
 #!     "name": "default",
 #!     "inputs": [
 #!         {

--- a/vyper/simple/overflow/positive/i64.vy
+++ b/vyper/simple/overflow/positive/i64.vy
@@ -1,4 +1,4 @@
-#! { "ignore": true, "cases": [ {
+#! { "modes": [ ">=0.3.9" ], "cases": [ {
 #!     "name": "default",
 #!     "inputs": [
 #!         {

--- a/vyper/simple/overflow/positive/i8.vy
+++ b/vyper/simple/overflow/positive/i8.vy
@@ -1,4 +1,4 @@
-#! { "ignore": true, "cases": [ {
+#! { "modes": [ ">=0.3.9" ], "cases": [ {
 #!     "name": "default",
 #!     "inputs": [
 #!         {

--- a/vyper/simple/overflow/positive/u16.vy
+++ b/vyper/simple/overflow/positive/u16.vy
@@ -1,4 +1,4 @@
-#! { "ignore": true, "cases": [ {
+#! { "modes": [ ">=0.3.9" ], "cases": [ {
 #!     "name": "default",
 #!     "inputs": [
 #!         {

--- a/vyper/simple/overflow/positive/u248.vy
+++ b/vyper/simple/overflow/positive/u248.vy
@@ -1,4 +1,4 @@
-#! { "ignore": true, "cases": [ {
+#! { "modes": [ ">=0.3.9" ], "cases": [ {
 #!     "name": "default",
 #!     "inputs": [
 #!         {

--- a/vyper/simple/overflow/positive/u32.vy
+++ b/vyper/simple/overflow/positive/u32.vy
@@ -1,4 +1,4 @@
-#! { "ignore": true, "cases": [ {
+#! { "modes": [ ">=0.3.9" ], "cases": [ {
 #!     "name": "default",
 #!     "inputs": [
 #!         {

--- a/vyper/simple/overflow/positive/u64.vy
+++ b/vyper/simple/overflow/positive/u64.vy
@@ -1,4 +1,4 @@
-#! { "ignore": true, "cases": [ {
+#! { "modes": [ ">=0.3.9" ], "cases": [ {
 #!     "name": "default",
 #!     "inputs": [
 #!         {


### PR DESCRIPTION
# What ❔

Turns on all tests disabled during the testing of Vyper v0.3.3.

## Why ❔

A lot of tests were disabled due to bugs present in the upstream Vyper compiler prior to v0.3.9 and v0.3.10.

## Checklist

- [x] PR title corresponds to the body of PR.
- [x] Tests for the changes have been added / updated.
- [x] Documentation comments have been added / updated.
