### PR TITLE
Add a test for swapping active pointers

### DIFF
--- a/solidity/complex/forwarding/swap/callable.sol
+++ b/solidity/complex/forwarding/swap/callable.sol
@@ -1,0 +1,17 @@
+// SPDX-License-Identifier: MIT
+
+pragma solidity >=0.6.0;
+
+contract Callable {
+    function first() public pure returns (uint256) {
+        return 1;
+    }
+
+    function second() public pure returns (uint256) {
+        return 2;
+    }
+
+    function third() public pure returns (uint256) {
+        return 3;
+    }
+}

--- a/solidity/complex/forwarding/swap/main.sol
+++ b/solidity/complex/forwarding/swap/main.sol
@@ -1,0 +1,84 @@
+// SPDX-License-Identifier: MIT
+
+pragma solidity >=0.6.0;
+
+import "./callable.sol";
+
+contract Main {
+    function main(address target) external view {
+        Callable callable = Callable(target);
+        callable.first();
+        assembly {
+            pop(staticcall(
+                0xFFFF,
+                0xFFEA,
+                0xFFFF,
+                0xFFFF,
+                0xFFFF,
+                0xFFFF
+            ))
+            pop(staticcall(
+                0,
+                0xFFD9,
+                1,
+                0xFFFF,
+                0xFFFF,
+                0xFFFF
+            ))
+        }
+        callable.second();
+        assembly {
+            pop(staticcall(
+                0xFFFF,
+                0xFFEA,
+                0xFFFF,
+                0xFFFF,
+                0xFFFF,
+                0xFFFF
+            ))
+            pop(staticcall(
+                0,
+                0xFFD9,
+                2,
+                0xFFFF,
+                0xFFFF,
+                0xFFFF
+            ))
+        }
+        callable.third();
+        assembly {
+            pop(staticcall(
+                0xFFFF,
+                0xFFEA,
+                0xFFFF,
+                0xFFFF,
+                0xFFFF,
+                0xFFFF
+            ))
+            pop(staticcall(
+                0,
+                0xFFD9,
+                3,
+                0xFFFF,
+                0xFFFF,
+                0xFFFF
+            ))
+            pop(staticcall(
+                0,
+                0xFFD9,
+                1,
+                0xFFFF,
+                0xFFFF,
+                0xFFFF
+            ))
+            pop(staticcall(
+                0xFFFF,
+                0xFFDB,
+                0xFFFF,
+                0xFFFF,
+                0xFFFF,
+                0xFFFF
+            ))
+        }
+    }
+}

--- a/solidity/complex/forwarding/swap/test.json
+++ b/solidity/complex/forwarding/swap/test.json
@@ -1,0 +1,20 @@
+{ "system_mode": true, "modes": [ "Y" ], "cases": [ {
+    "name": "short",
+    "inputs": [
+        {
+            "instance": "Main",
+            "method": "main",
+            "calldata": [
+                "Callable.address"
+            ]
+        }
+    ],
+    "expected": [
+        "1"
+    ]
+} ],
+    "contracts": {
+        "Main": "main.sol:Main",
+        "Callable": "callable.sol:Callable"
+    }
+}

--- a/solidity/simple/constructor/active_ptr_calldata_size.sol
+++ b/solidity/simple/constructor/active_ptr_calldata_size.sol
@@ -1,0 +1,70 @@
+//! { "system_mode": true, "modes": [ "Y" ], "cases": [ {
+//!     "name": "default",
+//!     "inputs": [
+//!         {
+//!             "method": "#deployer",
+//!             "calldata": [
+//!                 "0x20",
+//!                 "0x20",
+//!                 "0x2a"
+//!             ],
+//!             "expected": [ "*" ]
+//!         },
+//!         {
+//!             "method": "size",
+//!             "calldata": [],
+//!             "expected": [
+//!                 "96"
+//!             ]
+//!         },
+//!         {
+//!             "method": "element",
+//!             "calldata": []
+//!         }
+//!     ],
+//!     "expected": [
+//!         "42"
+//!     ]
+//! } ] }
+
+// SPDX-License-Identifier: MIT
+
+pragma solidity >=0.6.0;
+
+contract Test {
+    uint public size;
+    uint public element;
+
+    constructor(bytes memory) {
+        uint calldata_size;
+        uint calldata_element;
+        assembly {
+            pop(staticcall(
+                0xFFFF,
+                0xFFEB,
+                0xFFFF,
+                0xFFFF,
+                0xFFFF,
+                0xFFFF
+            ))
+            calldata_size := staticcall(
+                0xFFFF,
+                0xFFE2,
+                0xFFFF,
+                0xFFFF,
+                0xFFFF,
+                0xFFFF
+            )
+            calldata_element := staticcall(
+                64,
+                0xFFE4,
+                0xFFFF,
+                0xFFFF,
+                0xFFFF,
+                0xFFFF
+            )
+        }
+        size = calldata_size;
+        element = calldata_element;
+    }
+}


### PR DESCRIPTION
# What ❔

Adds a simulation to swap active pointers.

## Why ❔

We are allowing 16 saved pointers now, where 0th will be the active one.

## Checklist

- [x] PR title corresponds to the body of PR.
- [x] Tests for the changes have been added / updated.
