### PR TITLE
Fix memset LLVM IR tests

### DIFF
--- a/llvm/memset/memset_0.ll
+++ b/llvm/memset/memset_0.ll
@@ -659,7 +659,7 @@ runtime:
   store i256 %cell_3, i256 addrspace(1)* inttoptr (i256 64 to i256 addrspace(1)*), align 32
 
   %write_ptr = inttoptr i256 %offset to i256 addrspace(1)*
-  call void @__memset_uma_as1(i256 addrspace(1)* align 1 %write_ptr, i256 %value, i256 0, i1 false)
+  call void @__memset_uma_as1(i256 addrspace(1)* align 1 %write_ptr, i256 %value, i256 0)
 
   %abi_data = shl i256 96, 96
   tail call void @llvm.eravm.return(i256 %abi_data) #1
@@ -679,7 +679,7 @@ define private void @__constructor() local_unnamed_addr #0 personality i32 ()* @
 ; Function Attrs: noreturn nounwind
 declare void @llvm.eravm.return(i256) #0
 
-declare void @__memset_uma_as1(i256 addrspace(1)*, i256, i256, i1)
+declare void @__memset_uma_as1(i256 addrspace(1)*, i256, i256)
 
 attributes #0 = { noreturn nounwind }
 attributes #1 = { nounwind }

--- a/llvm/memset/memset_0n.ll
+++ b/llvm/memset/memset_0n.ll
@@ -695,7 +695,7 @@ runtime:
   store i256 %cell_3, i256 addrspace(1)* inttoptr (i256 64 to i256 addrspace(1)*), align 32
 
   %write_ptr = inttoptr i256 %offset to i256 addrspace(1)*
-  call void @__memset_uma_as1(i256 addrspace(1)* align 1 %write_ptr, i256 %value, i256 %size, i1 false)
+  call void @__memset_uma_as1(i256 addrspace(1)* align 1 %write_ptr, i256 %value, i256 %size)
 
   %abi_data = shl i256 96, 96
   tail call void @llvm.eravm.return(i256 %abi_data) #1
@@ -715,7 +715,7 @@ define private void @__constructor() local_unnamed_addr #0 personality i32 ()* @
 ; Function Attrs: noreturn nounwind
 declare void @llvm.eravm.return(i256) #0
 
-declare void @__memset_uma_as1(i256 addrspace(1)*, i256, i256, i1)
+declare void @__memset_uma_as1(i256 addrspace(1)*, i256, i256)
 
 attributes #0 = { noreturn nounwind }
 attributes #1 = { nounwind }

--- a/llvm/memset/memset_20.ll
+++ b/llvm/memset/memset_20.ll
@@ -659,7 +659,7 @@ runtime:
   store i256 %cell_3, i256 addrspace(1)* inttoptr (i256 64 to i256 addrspace(1)*), align 32
 
   %write_ptr = inttoptr i256 %offset to i256 addrspace(1)*
-  call void @__memset_uma_as1(i256 addrspace(1)* align 1 %write_ptr, i256 %value, i256 20, i1 false)
+  call void @__memset_uma_as1(i256 addrspace(1)* align 1 %write_ptr, i256 %value, i256 20)
 
   %abi_data = shl i256 96, 96
   tail call void @llvm.eravm.return(i256 %abi_data) #1
@@ -679,7 +679,7 @@ define private void @__constructor() local_unnamed_addr #0 personality i32 ()* @
 ; Function Attrs: noreturn nounwind
 declare void @llvm.eravm.return(i256) #0
 
-declare void @__memset_uma_as1(i256 addrspace(1)*, i256, i256, i1)
+declare void @__memset_uma_as1(i256 addrspace(1)*, i256, i256)
 
 attributes #0 = { noreturn nounwind }
 attributes #1 = { nounwind }

--- a/llvm/memset/memset_20n.ll
+++ b/llvm/memset/memset_20n.ll
@@ -695,7 +695,7 @@ runtime:
   store i256 %cell_3, i256 addrspace(1)* inttoptr (i256 64 to i256 addrspace(1)*), align 32
 
   %write_ptr = inttoptr i256 %offset to i256 addrspace(1)*
-  call void @__memset_uma_as1(i256 addrspace(1)* align 1 %write_ptr, i256 %value, i256 %size, i1 false)
+  call void @__memset_uma_as1(i256 addrspace(1)* align 1 %write_ptr, i256 %value, i256 %size)
 
   %abi_data = shl i256 96, 96
   tail call void @llvm.eravm.return(i256 %abi_data) #1
@@ -715,7 +715,7 @@ define private void @__constructor() local_unnamed_addr #0 personality i32 ()* @
 ; Function Attrs: noreturn nounwind
 declare void @llvm.eravm.return(i256) #0
 
-declare void @__memset_uma_as1(i256 addrspace(1)*, i256, i256, i1)
+declare void @__memset_uma_as1(i256 addrspace(1)*, i256, i256)
 
 attributes #0 = { noreturn nounwind }
 attributes #1 = { nounwind }

--- a/llvm/memset/memset_32.ll
+++ b/llvm/memset/memset_32.ll
@@ -659,7 +659,7 @@ runtime:
   store i256 %cell_3, i256 addrspace(1)* inttoptr (i256 64 to i256 addrspace(1)*), align 32
 
   %write_ptr = inttoptr i256 %offset to i256 addrspace(1)*
-  call void @__memset_uma_as1(i256 addrspace(1)* align 1 %write_ptr, i256 %value, i256 32, i1 false)
+  call void @__memset_uma_as1(i256 addrspace(1)* align 1 %write_ptr, i256 %value, i256 32)
 
   %abi_data = shl i256 96, 96
   tail call void @llvm.eravm.return(i256 %abi_data) #1
@@ -679,7 +679,7 @@ define private void @__constructor() local_unnamed_addr #0 personality i32 ()* @
 ; Function Attrs: noreturn nounwind
 declare void @llvm.eravm.return(i256) #0
 
-declare void @__memset_uma_as1(i256 addrspace(1)*, i256, i256, i1)
+declare void @__memset_uma_as1(i256 addrspace(1)*, i256, i256)
 
 attributes #0 = { noreturn nounwind }
 attributes #1 = { nounwind }

--- a/llvm/memset/memset_32n.ll
+++ b/llvm/memset/memset_32n.ll
@@ -695,7 +695,7 @@ runtime:
   store i256 %cell_3, i256 addrspace(1)* inttoptr (i256 64 to i256 addrspace(1)*), align 32
 
   %write_ptr = inttoptr i256 %offset to i256 addrspace(1)*
-  call void @__memset_uma_as1(i256 addrspace(1)* align 1 %write_ptr, i256 %value, i256 %size, i1 false)
+  call void @__memset_uma_as1(i256 addrspace(1)* align 1 %write_ptr, i256 %value, i256 %size)
 
   %abi_data = shl i256 96, 96
   tail call void @llvm.eravm.return(i256 %abi_data) #1
@@ -715,7 +715,7 @@ define private void @__constructor() local_unnamed_addr #0 personality i32 ()* @
 ; Function Attrs: noreturn nounwind
 declare void @llvm.eravm.return(i256) #0
 
-declare void @__memset_uma_as1(i256 addrspace(1)*, i256, i256, i1)
+declare void @__memset_uma_as1(i256 addrspace(1)*, i256, i256)
 
 attributes #0 = { noreturn nounwind }
 attributes #1 = { nounwind }

--- a/llvm/memset/memset_41.ll
+++ b/llvm/memset/memset_41.ll
@@ -659,7 +659,7 @@ runtime:
   store i256 %cell_3, i256 addrspace(1)* inttoptr (i256 64 to i256 addrspace(1)*), align 32
 
   %write_ptr = inttoptr i256 %offset to i256 addrspace(1)*
-  call void @__memset_uma_as1(i256 addrspace(1)* align 1 %write_ptr, i256 %value, i256 41, i1 false)
+  call void @__memset_uma_as1(i256 addrspace(1)* align 1 %write_ptr, i256 %value, i256 41)
 
   %abi_data = shl i256 96, 96
   tail call void @llvm.eravm.return(i256 %abi_data) #1
@@ -679,7 +679,7 @@ define private void @__constructor() local_unnamed_addr #0 personality i32 ()* @
 ; Function Attrs: noreturn nounwind
 declare void @llvm.eravm.return(i256) #0
 
-declare void @__memset_uma_as1(i256 addrspace(1)*, i256, i256, i1)
+declare void @__memset_uma_as1(i256 addrspace(1)*, i256, i256)
 
 attributes #0 = { noreturn nounwind }
 attributes #1 = { nounwind }

--- a/llvm/memset/memset_41n.ll
+++ b/llvm/memset/memset_41n.ll
@@ -695,7 +695,7 @@ runtime:
   store i256 %cell_3, i256 addrspace(1)* inttoptr (i256 64 to i256 addrspace(1)*), align 32
 
   %write_ptr = inttoptr i256 %offset to i256 addrspace(1)*
-  call void @__memset_uma_as1(i256 addrspace(1)* align 1 %write_ptr, i256 %value, i256 %size, i1 false)
+  call void @__memset_uma_as1(i256 addrspace(1)* align 1 %write_ptr, i256 %value, i256 %size)
 
   %abi_data = shl i256 96, 96
   tail call void @llvm.eravm.return(i256 %abi_data) #1
@@ -715,7 +715,7 @@ define private void @__constructor() local_unnamed_addr #0 personality i32 ()* @
 ; Function Attrs: noreturn nounwind
 declare void @llvm.eravm.return(i256) #0
 
-declare void @__memset_uma_as1(i256 addrspace(1)*, i256, i256, i1)
+declare void @__memset_uma_as1(i256 addrspace(1)*, i256, i256)
 
 attributes #0 = { noreturn nounwind }
 attributes #1 = { nounwind }

--- a/llvm/memset/memset_64.ll
+++ b/llvm/memset/memset_64.ll
@@ -659,7 +659,7 @@ runtime:
   store i256 %cell_3, i256 addrspace(1)* inttoptr (i256 64 to i256 addrspace(1)*), align 32
 
   %write_ptr = inttoptr i256 %offset to i256 addrspace(1)*
-  call void @__memset_uma_as1(i256 addrspace(1)* align 1 %write_ptr, i256 %value, i256 64, i1 false)
+  call void @__memset_uma_as1(i256 addrspace(1)* align 1 %write_ptr, i256 %value, i256 64)
 
   %abi_data = shl i256 96, 96
   tail call void @llvm.eravm.return(i256 %abi_data) #1
@@ -679,7 +679,7 @@ define private void @__constructor() local_unnamed_addr #0 personality i32 ()* @
 ; Function Attrs: noreturn nounwind
 declare void @llvm.eravm.return(i256) #0
 
-declare void @__memset_uma_as1(i256 addrspace(1)*, i256, i256, i1)
+declare void @__memset_uma_as1(i256 addrspace(1)*, i256, i256)
 
 attributes #0 = { noreturn nounwind }
 attributes #1 = { nounwind }

--- a/llvm/memset/memset_64n.ll
+++ b/llvm/memset/memset_64n.ll
@@ -695,7 +695,7 @@ runtime:
   store i256 %cell_3, i256 addrspace(1)* inttoptr (i256 64 to i256 addrspace(1)*), align 32
 
   %write_ptr = inttoptr i256 %offset to i256 addrspace(1)*
-  call void @__memset_uma_as1(i256 addrspace(1)* align 1 %write_ptr, i256 %value, i256 %size, i1 false)
+  call void @__memset_uma_as1(i256 addrspace(1)* align 1 %write_ptr, i256 %value, i256 %size)
 
   %abi_data = shl i256 96, 96
   tail call void @llvm.eravm.return(i256 %abi_data) #1
@@ -715,7 +715,7 @@ define private void @__constructor() local_unnamed_addr #0 personality i32 ()* @
 ; Function Attrs: noreturn nounwind
 declare void @llvm.eravm.return(i256) #0
 
-declare void @__memset_uma_as1(i256 addrspace(1)*, i256, i256, i1)
+declare void @__memset_uma_as1(i256 addrspace(1)*, i256, i256)
 
 attributes #0 = { noreturn nounwind }
 attributes #1 = { nounwind }


### PR DESCRIPTION
`__memset_uma_as1` is defined as `void(i256 addrspace(1)*, i256, i256)` but used as `void(i256 addrspace(1)*, i256, i256, i1)`. It creates a bitcast in LLVM IR, so global DCE don't remove unnecessary calls.

# What ❔

<!-- What are the changes this PR brings about? -->
<!-- Example: This PR adds a PR template to the repo. -->
<!-- (For bigger PRs adding more context is appreciated) -->

## Why ❔

<!-- Why are these changes done? What goal do they contribute to? What are the principles behind them? -->
<!-- Example: PR templates ensure PR reviewers, observers, and future iterators are in context about the evolution of repos. -->

## Checklist

<!-- Check your PR fulfills the following items. -->
<!-- For draft PRs check the boxes as you complete them. -->

- [ ] PR title corresponds to the body of PR.
- [ ] Documentation comments have been added / updated.
