### PR TITLE
chore: apply ZKsync rebranding

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -34,7 +34,7 @@ We aim to make it as easy as possible to contribute to the mission. This is stil
 and suggestions here too. Some resources to help:
 
 1. [In-repo docs aimed at developers](docs)
-2. [zkSync Era docs!](https://era.zksync.io/docs/)
+2. [ZKsync Era docs!](https://era.zksync.io/docs/)
 3. Company links can be found in the [repo's readme](README.md)
 
 ## Code of Conduct

--- a/README.md
+++ b/README.md
@@ -1,10 +1,10 @@
-# zkSync Era: The EraVM Compiler Tests Collection
+# ZKsync Era: The ZKsync Compiler Tests Collection
 
 [![Logo](eraLogo.svg)](https://zksync.io/)
 
-zkSync Era is a layer 2 rollup that uses zero-knowledge proofs to scale Ethereum without compromising on security
+ZKsync Era is a layer 2 rollup that uses zero-knowledge proofs to scale Ethereum without compromising on security
 or decentralization. As it's EVM-compatible (with Solidity/Vyper), 99% of Ethereum projects can redeploy without
-needing to refactor or re-audit any code. zkSync Era also uses an LLVM-based compiler that will eventually enable
+needing to refactor or re-audit any code. ZKsync Era also uses an LLVM-based compiler that will eventually enable
 developers to write smart contracts in popular languages such as C++ and Rust.
 
 This repository contains the collection of tests for the EraVM compilers.
@@ -18,7 +18,7 @@ This repository contains three types of tests:
 - Complex - multi-contract tests created by Matter Labs and vendored DeFi projects developed by other organizations.
 
 The `solidity` and `vyper` directories have three subdirectories each, one for each type.
-The `yul`, `llvm`, and `zkevm` directories only contain Matter Labs simple tests as multi-contract projects are not supported in these languages.
+The `yul`, `llvm`, and `eravm` directories only contain Matter Labs simple tests as multi-contract projects are not supported in these languages.
 
 ## Matter Labs simple/complex format
 
@@ -143,7 +143,7 @@ Additionally, this repository vendors test projects preserving their original li
 - [Mooniswap](./solidity/complex/defi/Mooniswap)
 - [SHIT](./solidity/complex/defi/shitdao)
 
-These projects are modified for the purposes of testing our compiler toolchain and are not used outside of this repository.  
+These projects are modified for the purposes of testing our compiler toolchain and are not used outside of this repository.
 Visit the project directories to discover the terms of each license in detail. The projects are licensed in either per-file or
 per-project manner.
 
@@ -152,12 +152,12 @@ per-project manner.
 - [Website](https://zksync.io/)
 - [GitHub](https://github.com/matter-labs)
 - [Twitter](https://twitter.com/zksync)
-- [Twitter for Devs](https://twitter.com/zkSyncDevs)
+- [Twitter for Devs](https://twitter.com/ZKsyncDevs)
 - [Discord](https://join.zksync.dev/)
 
 ## Disclaimer
 
-zkSync Era has been through extensive testing and audits, and although it is live, it is still in alpha state and
+ZKsync Era has been through extensive testing and audits, and although it is live, it is still in alpha state and
 will undergo further audits and bug bounty programs. We would love to hear our community's thoughts and suggestions
 about it!
 It's important to note that forking it now could potentially lead to missing important


### PR DESCRIPTION
# What ❔

<!-- What are the changes this PR brings about? -->
<!-- Example: This PR adds a PR template to the repo. -->
<!-- (For bigger PRs adding more context is appreciated) -->

Rebranding from zkSync and zkevm to ZKsync and EraVM.

## Why ❔

<!-- Why are these changes done? What goal do they contribute to? What are the principles behind them? -->
<!-- Example: PR templates ensure PR reviewers, observers, and future iterators are in context about the evolution of repos. -->

Related to [CPR-1695](https://linear.app/matterlabs/issue/CPR-1695/apply-the-rebranding-to-all-remaining-repos)

## Checklist

<!-- Check your PR fulfills the following items. -->
<!-- For draft PRs check the boxes as you complete them. -->

- [ ] PR title corresponds to the body of PR.
- [ ] Documentation comments have been added / updated.
