### PR TITLE
fix: burn all gas with assert unreachable

### DIFF
--- a/vyper/simple/error/assert_unreachable.vy
+++ b/vyper/simple/error/assert_unreachable.vy
@@ -1,0 +1,62 @@
+#! { "modes": [ "V >=0.3.10" ], "cases": [ {
+#!     "name": "default",
+#!     "inputs": [
+#!         {
+#!             "method": "foo",
+#!             "calldata": []
+#!         }
+#!     ],
+#!     "expected": [
+#!         "0x20", "0x04", "0", "1", "0", "1"
+#!     ]
+#! } ] }
+
+GAS_AMOUNT: constant(uint256) = 10000
+
+@external
+@payable
+def foo() -> DynArray[bool, 4]:
+    values: DynArray[bool, 4] = []
+    if True:
+        a1: uint256 = msg.gas
+        ret: bool = raw_call(self, method_id("assert_()"), revert_on_failure=False, gas = GAS_AMOUNT) 
+        a2: uint256 = msg.gas
+        assert not ret
+        values.append(a1 - a2 > GAS_AMOUNT)
+    if True:
+        a1: uint256 = msg.gas
+        ret: bool = raw_call(self, method_id("assert_unreachable()"), revert_on_failure=False, gas = GAS_AMOUNT) 
+        a2: uint256 = msg.gas
+        assert not ret
+        values.append(a1 - a2 > GAS_AMOUNT)
+    if True:
+        a1: uint256 = msg.gas
+        ret: bool = raw_call(self, method_id("raise_()"), revert_on_failure=False, gas = GAS_AMOUNT) 
+        a2: uint256 = msg.gas
+        assert not ret
+        values.append(a1 - a2 > GAS_AMOUNT)
+    if True:
+        a1: uint256 = msg.gas
+        ret: bool = raw_call(self, method_id("raise_unreachable()"), revert_on_failure=False, gas = GAS_AMOUNT) 
+        a2: uint256 = msg.gas
+        assert not ret
+        values.append(a1 - a2 > GAS_AMOUNT)
+    return values
+
+@external
+def assert_():
+    x:bool = False
+    assert x
+
+@external
+def assert_unreachable():
+    x:bool = False
+    assert x, UNREACHABLE
+
+@external
+def raise_():
+    raise
+
+@external
+def raise_unreachable():
+    raise UNREACHABLE


### PR DESCRIPTION
# What ❔

Burn all gas with assert unreachable.

Fixes https://github.com/matter-labs/era-compiler-vyper/issues/83

## Why ❔

It has been translated to the equivalent of `REVERT` instead of `INVALID`.

## Checklist

<!-- Check your PR fulfills the following items. -->
<!-- For draft PRs check the boxes as you complete them. -->

- [ ] PR title corresponds to the body of PR.
- [ ] Documentation comments have been added / updated.
