### PR TITLE
fix(eravm): resets return data after calling CREATE

### DIFF
--- a/solidity/simple/create/return_data_clear.sol
+++ b/solidity/simple/create/return_data_clear.sol
@@ -1,0 +1,46 @@
+//! { "cases": [ {
+//!     "name": "default",
+//!     "inputs": [
+//!         {
+//!             "method": "main",
+//!             "calldata": []
+//!         }
+//!     ],
+//!     "expected": [
+//!         "0x60",
+//!         "0x00"
+//!     ]
+//! } ] }
+
+// SPDX-License-Identifier: MIT
+
+pragma solidity >=0.8.0;
+
+contract Qux {}
+
+contract Bar {
+    function returnsSomething() public pure returns (bytes memory) {
+        return ("this is returned");
+    }
+}
+
+contract Test {
+    Bar bar;
+
+    constructor() {
+        bar = new Bar();
+    }
+
+    function main() public returns (uint256 returnsize1, uint256 returnsize2) {
+        address(bar).call(abi.encodeWithSelector(Bar.returnsSomething.selector));
+        assembly {
+            returnsize1 := returndatasize()
+        }
+
+        new Qux();
+
+        assembly {
+            returnsize2 := returndatasize()
+        }
+    }
+}

--- a/solidity/simple/error/default.sol
+++ b/solidity/simple/error/default.sol
@@ -1,5 +1,4 @@
-//! {
-//!   "cases": [ {
+//! { "cases": [ {
 //!     "name": "require_short",
 //!     "inputs": [
 //!         {


### PR DESCRIPTION
# What ❔

Cleares return data after calling `CREATE`/`CREATE2` (`ContractDeployer` system contract for EraVM).

## Why ❔

It is cleared on EVM, but not on EraVM.

## Checklist

<!-- Check your PR fulfills the following items. -->
<!-- For draft PRs check the boxes as you complete them. -->

- [x] PR title corresponds to the body of PR.
- [x] Documentation comments have been added / updated.
