### PR TITLE
fix: zero calldata/return data on failed proxy calls

### DIFF
--- a/vyper/complex/ethereum/salted_create/salted_create-0.3/test.json
+++ b/vyper/complex/ethereum/salted_create/salted_create-0.3/test.json
@@ -21,10 +21,7 @@
     ],
     "expected": {
         "exception": true,
-        "return_data": [
-            "0x9e4a3c8a01000035999a1d871cf4d876ed735fa6a8f3bbeb3f94d210bf4520ed",
-            "0x94f3565400000000000000000000000000000000000000000000000000000000"
-        ]
+        "return_data": []
     }
 } ],
     "contracts": {

--- a/vyper/complex/ethereum/salted_create/salted_create/test.json
+++ b/vyper/complex/ethereum/salted_create/salted_create/test.json
@@ -21,10 +21,7 @@
     ],
     "expected": {
         "exception": true,
-        "return_data": [
-            "0x9e4a3c8a01000035999a1d871cf4d876ed735fa6a8f3bbeb3f94d210bf4520ed",
-            "0x94f3565400000000000000000000000000000000000000000000000000000000"
-        ]
+        "return_data": []
     }
 } ],
     "contracts": {


### PR DESCRIPTION
# What ❔

Updates tests after fixing the bug with unzeroed calldata / return data after failed `CREATE`.

## Checklist

<!-- Check your PR fulfills the following items. -->
<!-- For draft PRs check the boxes as you complete them. -->

- [x] PR title corresponds to the body of PR.
- [x] Documentation comments have been added / updated.
