### PR TITLE
fix: disable tests for immutables for solc <0.8

### DIFF
--- a/solidity/complex/defi/UniswapV3/test_evm.json
+++ b/solidity/complex/defi/UniswapV3/test_evm.json
@@ -1,6 +1,4 @@
-{ "targets": [ "evm" ], "modes": [ "E+", "I", "Y" ],
-"comment": "E- solc error: too deep into the stack",
-"cases": [ {
+{ "targets": [ "evm" ], "modes": [ "Y" ], "cases": [ {
     "name": "default",
     "inputs": [
         {

--- a/solidity/simple/events/0_topics.sol
+++ b/solidity/simple/events/0_topics.sol
@@ -62,7 +62,7 @@
 
 // SPDX-License-Identifier: MIT
 
-pragma solidity >=0.7.5;
+pragma solidity >=0.8.0;
 pragma abicoder v2;
 
 contract Test {

--- a/solidity/simple/events/1_topic.sol
+++ b/solidity/simple/events/1_topic.sol
@@ -74,7 +74,7 @@
 
 // SPDX-License-Identifier: MIT
 
-pragma solidity >=0.7.5;
+pragma solidity >=0.8.0;
 pragma abicoder v2;
 
 contract Test {

--- a/solidity/simple/events/2_topics.sol
+++ b/solidity/simple/events/2_topics.sol
@@ -80,7 +80,7 @@
 
 // SPDX-License-Identifier: MIT
 
-pragma solidity >=0.7.5;
+pragma solidity >=0.8.0;
 pragma abicoder v2;
 
 contract Test {

--- a/solidity/simple/events/3_topics.sol
+++ b/solidity/simple/events/3_topics.sol
@@ -86,7 +86,7 @@
 
 // SPDX-License-Identifier: MIT
 
-pragma solidity >=0.7.5;
+pragma solidity >=0.8.0;
 pragma abicoder v2;
 
 contract Test {

--- a/solidity/simple/events/4_topics.sol
+++ b/solidity/simple/events/4_topics.sol
@@ -92,7 +92,7 @@
 
 // SPDX-License-Identifier: MIT
 
-pragma solidity >=0.7.5;
+pragma solidity >=0.8.0;
 pragma abicoder v2;
 
 contract Test {

--- a/solidity/simple/immutable_eravm/aligned/complex_operator.sol
+++ b/solidity/simple/immutable_eravm/aligned/complex_operator.sol
@@ -1,0 +1,45 @@
+//! { "targets": [ "eravm" ], "cases": [ {
+//!     "name": "main",
+//!     "inputs": [
+//!         {
+//!             "method": "#deployer",
+//!             "calldata": [
+//!                 "0x03",
+//!                 "0x05",
+//!                 "0x02"
+//!             ],
+//!             "expected": [
+//!                 "Test.address"
+//!             ]
+//!         },
+//!         {
+//!             "method": "main",
+//!             "calldata": [
+//!                 "16"
+//!             ]
+//!         }
+//!     ],
+//!     "expected": [
+//!         "81"
+//!     ]
+//! } ] }
+
+// SPDX-License-Identifier: MIT
+
+pragma solidity >=0.6.5;
+
+contract Test {
+    uint256 immutable field_1;
+    uint256 immutable field_2;
+    uint256 immutable field_3;
+
+    constructor(uint256 a, uint256 b, uint256 c) public {
+        field_1 = a;
+        field_2 = b;
+        field_3 = c;
+    }
+
+    function main(uint8 witness) external returns(uint8) {
+        return 19 * 3 - 8 / uint8(field_1) + (witness / (uint8(field_2) - 3) + 5) * (8 / uint8(field_3) / 2);
+    }
+}

--- a/solidity/simple/immutable_eravm/aligned/method_chain.sol
+++ b/solidity/simple/immutable_eravm/aligned/method_chain.sol
@@ -1,4 +1,4 @@
-//! { "cases": [ {
+//! { "targets": [ "eravm" ], "cases": [ {
 //!     "name": "main",
 //!     "inputs": [
 //!         {

--- a/solidity/simple/immutable_eravm/aligned/mixed_data_origin.sol
+++ b/solidity/simple/immutable_eravm/aligned/mixed_data_origin.sol
@@ -1,0 +1,56 @@
+//! { "targets": [ "eravm" ], "cases": [ {
+//!     "name": "main",
+//!     "inputs": [
+//!         {
+//!             "method": "#deployer",
+//!             "calldata": [
+//!                 "0x05",
+//!                 "0x07"
+//!             ],
+//!             "expected": [
+//!                 "Test.address"
+//!             ]
+//!         },
+//!         {
+//!             "method": "main",
+//!             "calldata": [
+//!                 "42"
+//!             ]
+//!         }
+//!     ],
+//!     "expected": [
+//!         "148"
+//!     ]
+//! } ] }
+
+// SPDX-License-Identifier: MIT
+
+pragma solidity >=0.6.5;
+
+contract Test {
+    uint256 constant SOMETHING = 42;
+    uint256 constant SOMETHING_ELSE = 88;
+
+    struct Data {
+        uint256 c;
+        uint256 d;
+    }
+
+    uint256 immutable a;
+    uint256 immutable b;
+
+    constructor(uint256 x, uint256 y) public {
+        a = x;
+        b = y;
+    }
+
+    function inner(Data memory data, uint256 _value, uint8 literal) internal returns(uint256) {
+        return ((a + data.c + b + data.d + _value) * literal * SOMETHING - SOMETHING_ELSE) / 1000;
+    }
+
+    function main(uint256 _value) external returns(uint256) {
+        Data memory data = Data({c: 10, d: 20});
+
+        return inner(data, _value, 42);
+    }
+}

--- a/solidity/simple/immutable_eravm/aligned/simple_operator.sol
+++ b/solidity/simple/immutable_eravm/aligned/simple_operator.sol
@@ -1,4 +1,4 @@
-//! { "cases": [ {
+//! { "targets": [ "eravm" ], "cases": [ {
 //!     "name": "main",
 //!     "inputs": [
 //!         {
@@ -29,17 +29,17 @@
 pragma solidity >=0.6.5;
 
 contract Test {
-    uint8 immutable field_1;
-    uint8 immutable field_2;
-    uint8 immutable field_3;
+    uint256 immutable field_1;
+    uint256 immutable field_2;
+    uint256 immutable field_3;
 
-    constructor(uint8 a, uint8 b, uint8 c) public {
+    constructor(uint256 a, uint256 b, uint256 c) public {
         field_1 = a;
         field_2 = b;
         field_3 = c;
     }
 
     function main(uint8 witness) external returns(uint8) {
-        return witness + field_1 * field_2 * field_3;
+        return witness + uint8(field_1) * uint8(field_2) * uint8(field_3);
     }
 }

--- a/solidity/simple/immutable_eravm/constructor.sol
+++ b/solidity/simple/immutable_eravm/constructor.sol
@@ -1,4 +1,4 @@
-//! { "cases": [ {
+//! { "targets": [ "eravm" ], "cases": [ {
 //!     "name": "default",
 //!     "inputs": [
 //!         {

--- a/solidity/simple/immutable_eravm/inheritance/immutables1.sol
+++ b/solidity/simple/immutable_eravm/inheritance/immutables1.sol
@@ -1,0 +1,53 @@
+//! { "targets": [ "eravm" ], "cases": [ {
+//!     "name": "test",
+//!     "inputs": [
+//!         {
+//!             "method": "f",
+//!             "calldata": [
+//!             ]
+//!         }
+//!     ],
+//!     "expected": [
+//!         "5", "6", "7"
+//!     ]
+//! } ] }
+
+// SPDX-License-Identifier: MIT
+
+pragma solidity >=0.8.20;
+
+contract TestC {
+    uint256 immutable z;
+
+    constructor() {
+        z = 7;
+    }
+
+    function fC() public returns (uint256) {
+        return z;
+    }
+}
+
+contract TestB is TestC {
+    uint256 immutable y;
+
+    constructor() {
+        y = 6;
+    }
+
+    function fB() public returns (uint256) {
+        return y;
+    }
+}
+
+contract Test is TestC, TestB {
+    uint256 immutable x;
+
+    constructor() {
+        x = 5;
+    }
+
+    function f() public returns (uint256, uint256, uint256) {
+        return (x, y, z);
+    }
+}

--- a/solidity/simple/immutable_eravm/inheritance/immutables2.sol
+++ b/solidity/simple/immutable_eravm/inheritance/immutables2.sol
@@ -1,18 +1,16 @@
-//! { "modes": [ "E" ], "cases": [{
+//! { "targets": [ "eravm" ], "cases": [ {
 //!     "name": "test",
 //!     "inputs": [
 //!         {
 //!             "method": "f",
-//!             "calldata": []
+//!             "calldata": [
+//!             ]
 //!         }
 //!     ],
 //!     "expected": [
-//!         "8",
-//!         "8",
-//!         "8"
+//!         "7", "6", "7"
 //!     ]
-//!     }
-//! ]}
+//! } ] }
 
 // SPDX-License-Identifier: MIT
 
@@ -20,22 +18,21 @@ pragma solidity >=0.8.20;
 
 contract TestC {
     uint256 immutable z;
-    uint s = 8;
 
-    constructor(uint _val) {
-        z = _val;
+    constructor() {
+        z = 7;
     }
 
     function fC() public returns (uint256) {
-        return s;
+        return z;
     }
 }
 
 contract TestB is TestC {
     uint256 immutable y;
 
-    constructor(uint _val) TestC(_val) {
-        y = fC();
+    constructor() {
+        y = 6;
     }
 
     function fB() public returns (uint256) {
@@ -46,8 +43,8 @@ contract TestB is TestC {
 contract Test is TestC, TestB {
     uint256 immutable x;
 
-    constructor() TestB(fC()) {
-        x = z;
+    constructor() {
+        x = fC();
     }
 
     function f() public returns (uint256, uint256, uint256) {

--- a/solidity/simple/immutable_eravm/inheritance/immutables3.sol
+++ b/solidity/simple/immutable_eravm/inheritance/immutables3.sol
@@ -1,4 +1,4 @@
-//! { "cases": [ {
+//! { "targets": [ "eravm" ], "cases": [ {
 //!     "name": "test",
 //!     "inputs": [
 //!         {
@@ -8,7 +8,7 @@
 //!         }
 //!     ],
 //!     "expected": [
-//!         "7", "6", "7"
+//!         "5", "0", "7"
 //!     ]
 //! } ] }
 
@@ -31,8 +31,8 @@ contract TestC {
 contract TestB is TestC {
     uint256 immutable y;
 
-    constructor() {
-        y = 6;
+    constructor(uint _val) {
+        y = _val;
     }
 
     function fB() public returns (uint256) {
@@ -43,8 +43,8 @@ contract TestB is TestC {
 contract Test is TestC, TestB {
     uint256 immutable x;
 
-    constructor() {
-        x = fC();
+    constructor() TestB(fC()) {
+        x = 5;
     }
 
     function f() public returns (uint256, uint256, uint256) {

--- a/solidity/simple/immutable_eravm/inheritance/immutables4.sol
+++ b/solidity/simple/immutable_eravm/inheritance/immutables4.sol
@@ -1,4 +1,4 @@
-//! { "cases": [ {
+//! { "targets": [ "eravm" ], "cases": [ {
 //!     "name": "test",
 //!     "inputs": [
 //!         {

--- a/solidity/simple/immutable_eravm/inheritance/immutables5.sol
+++ b/solidity/simple/immutable_eravm/inheritance/immutables5.sol
@@ -1,0 +1,53 @@
+//! { "targets": [ "eravm" ], "cases": [ {
+//!     "name": "test",
+//!     "inputs": [
+//!         {
+//!             "method": "f",
+//!             "calldata": [
+//!             ]
+//!         }
+//!     ],
+//!     "expected": [
+//!         "2", "0", "2"
+//!     ]
+//! } ] }
+
+// SPDX-License-Identifier: MIT
+
+pragma solidity >=0.8.20;
+
+contract TestC {
+    uint256 immutable z;
+
+    constructor(uint _val) {
+        z = _val;
+    }
+
+    function fC() public returns (uint256) {
+        return z;
+    }
+}
+
+contract TestB is TestC {
+    uint256 immutable y;
+
+    constructor(uint _val) TestC(2) {
+        y = _val;
+    }
+
+    function fB() public returns (uint256) {
+        return y;
+    }
+}
+
+contract Test is TestC, TestB {
+    uint256 immutable x;
+
+    constructor() TestB(fC()) {
+        x = z;
+    }
+
+    function f() public returns (uint256, uint256, uint256) {
+        return (x, y, z);
+    }
+}

--- a/solidity/simple/immutable_eravm/inheritance/immutables6_legacy.sol
+++ b/solidity/simple/immutable_eravm/inheritance/immutables6_legacy.sol
@@ -1,0 +1,56 @@
+//! { "modes": [ "E" ], "targets": [ "eravm" ], "cases": [{
+//!     "name": "test",
+//!     "inputs": [
+//!         {
+//!             "method": "f",
+//!             "calldata": []
+//!         }
+//!     ],
+//!     "expected": [
+//!         "8",
+//!         "8",
+//!         "8"
+//!     ]
+//!     }
+//! ]}
+
+// SPDX-License-Identifier: MIT
+
+pragma solidity >=0.8.20;
+
+contract TestC {
+    uint256 immutable z;
+    uint s = 8;
+
+    constructor(uint _val) {
+        z = _val;
+    }
+
+    function fC() public returns (uint256) {
+        return s;
+    }
+}
+
+contract TestB is TestC {
+    uint256 immutable y;
+
+    constructor(uint _val) TestC(_val) {
+        y = fC();
+    }
+
+    function fB() public returns (uint256) {
+        return y;
+    }
+}
+
+contract Test is TestC, TestB {
+    uint256 immutable x;
+
+    constructor() TestB(fC()) {
+        x = z;
+    }
+
+    function f() public returns (uint256, uint256, uint256) {
+        return (x, y, z);
+    }
+}

--- a/solidity/simple/immutable_eravm/inheritance/immutables6_yul.sol
+++ b/solidity/simple/immutable_eravm/inheritance/immutables6_yul.sol
@@ -1,0 +1,56 @@
+//! { "modes": [ "Y", "I" ], "targets": [ "eravm" ], "cases": [{
+//!     "name": "test",
+//!     "inputs": [
+//!         {
+//!             "method": "f",
+//!             "calldata": []
+//!         }
+//!     ],
+//!     "expected": [
+//!         "0",
+//!         "8",
+//!         "0"
+//!     ]
+//!     }
+//! ]}
+
+// SPDX-License-Identifier: MIT
+
+pragma solidity >=0.8.20;
+
+contract TestC {
+    uint256 immutable z;
+    uint s = 8;
+
+    constructor(uint _val) {
+        z = _val;
+    }
+
+    function fC() public returns (uint256) {
+        return s;
+    }
+}
+
+contract TestB is TestC {
+    uint256 immutable y;
+
+    constructor(uint _val) TestC(_val) {
+        y = fC();
+    }
+
+    function fB() public returns (uint256) {
+        return y;
+    }
+}
+
+contract Test is TestC, TestB {
+    uint256 immutable x;
+
+    constructor() TestB(fC()) {
+        x = z;
+    }
+
+    function f() public returns (uint256, uint256, uint256) {
+        return (x, y, z);
+    }
+}

--- a/solidity/simple/immutable_eravm/memory_manipulation.sol
+++ b/solidity/simple/immutable_eravm/memory_manipulation.sol
@@ -1,6 +1,6 @@
 //! { "modes": [
 //!     "Y", "E+ <=0.8.12", "E+ >=0.8.15", "E-", "I"
-//! ], "cases": [
+//! ], "targets": [ "eravm" ], "cases": [
 //!         {
 //!             "name": "main",
 //!             "inputs": [

--- a/solidity/simple/immutable_eravm/trycatch.sol
+++ b/solidity/simple/immutable_eravm/trycatch.sol
@@ -1,0 +1,36 @@
+//! { "targets": [ "eravm" ], "cases": [ {
+//!     "name": "trycatch",
+//!     "inputs": [
+//!         {
+//!             "method": "f",
+//!             "calldata": [
+//!             ]
+//!         }
+//!     ],
+//!     "expected": [ "0" ]
+//! } ] }
+
+// SPDX-License-Identifier: MIT
+
+pragma solidity >=0.6.5 <=0.8.19;
+
+contract Test {
+    uint256 public immutable Temp;
+
+    constructor() public {
+        Test2 con = new Test2();
+        try con.f2() {
+            Temp = 5;
+        } catch {}
+    }
+
+    function f() public returns (uint256) {
+        return Temp;
+    }
+}
+
+contract Test2 {
+    function f2() public pure {
+        revert();
+    }
+}

--- a/solidity/simple/immutable_eravm/unaligned/complex_operator.sol
+++ b/solidity/simple/immutable_eravm/unaligned/complex_operator.sol
@@ -1,4 +1,4 @@
-//! { "cases": [ {
+//! { "targets": [ "eravm" ], "cases": [ {
 //!     "name": "main",
 //!     "inputs": [
 //!         {
@@ -15,12 +15,12 @@
 //!         {
 //!             "method": "main",
 //!             "calldata": [
-//!                 "12"
+//!                 "16"
 //!             ]
 //!         }
 //!     ],
 //!     "expected": [
-//!         "42"
+//!         "81"
 //!     ]
 //! } ] }
 
@@ -29,17 +29,17 @@
 pragma solidity >=0.6.5;
 
 contract Test {
-    uint256 immutable field_1;
-    uint256 immutable field_2;
-    uint256 immutable field_3;
+    uint8 immutable field_1;
+    uint8 immutable field_2;
+    uint8 immutable field_3;
 
-    constructor(uint256 a, uint256 b, uint256 c) public {
+    constructor(uint8 a, uint8 b, uint8 c) public {
         field_1 = a;
         field_2 = b;
         field_3 = c;
     }
 
     function main(uint8 witness) external returns(uint8) {
-        return witness + uint8(field_1) * uint8(field_2) * uint8(field_3);
+        return 19 * 3 - 8 / field_1 + (witness / (field_2 - 3) + 5) * (8 / field_3 / 2);
     }
 }

--- a/solidity/simple/immutable_eravm/unaligned/method_chain.sol
+++ b/solidity/simple/immutable_eravm/unaligned/method_chain.sol
@@ -1,0 +1,54 @@
+//! { "targets": [ "eravm" ], "cases": [ {
+//!     "name": "main",
+//!     "inputs": [
+//!         {
+//!             "method": "#deployer",
+//!             "calldata": [
+//!                 "0x05",
+//!                 "0x0b"
+//!             ],
+//!             "expected": [
+//!                 "Test.address"
+//!             ]
+//!         },
+//!         {
+//!             "method": "main",
+//!             "calldata": [
+//!                 "42"
+//!             ]
+//!         }
+//!     ],
+//!     "expected": [
+//!         "1024"
+//!     ]
+//! } ] }
+
+// SPDX-License-Identifier: MIT
+
+pragma solidity >=0.6.5;
+
+contract Test {
+    uint8 immutable a;
+    uint8 immutable b;
+
+    constructor(uint8 x, uint8 y) public {
+        a = x;
+        b = y;
+    }
+
+    function double(uint256 _value) internal returns(uint256) {
+        return _value * 2;
+    }
+
+    function triple(uint256 _value) internal returns(uint256) {
+        return 3 * _value;
+    }
+
+    function quadruple(uint256 _value) internal returns(uint256) {
+        return _value * 4;
+    }
+
+    function main(uint256 _value) external returns(uint256) {
+        return a + quadruple(triple(double(_value))) + b;
+    }
+}

--- a/solidity/simple/immutable_eravm/unaligned/mixed_data_origin.sol
+++ b/solidity/simple/immutable_eravm/unaligned/mixed_data_origin.sol
@@ -1,0 +1,56 @@
+//! { "targets": [ "eravm" ], "cases": [ {
+//!     "name": "main",
+//!     "inputs": [
+//!         {
+//!             "method": "#deployer",
+//!             "calldata": [
+//!                 "0x05",
+//!                 "0x07"
+//!             ],
+//!             "expected": [
+//!                 "Test.address"
+//!             ]
+//!         },
+//!         {
+//!             "method": "main",
+//!             "calldata": [
+//!                 "42"
+//!             ]
+//!         }
+//!     ],
+//!     "expected": [
+//!         "148"
+//!     ]
+//! } ] }
+
+// SPDX-License-Identifier: MIT
+
+pragma solidity >=0.6.5;
+
+contract Test {
+    uint256 constant SOMETHING = 42;
+    uint256 constant SOMETHING_ELSE = 88;
+
+    struct Data {
+        uint256 c;
+        uint256 d;
+    }
+
+    uint8 immutable a;
+    uint8 immutable b;
+
+    constructor(uint8 x, uint8 y) public {
+        a = x;
+        b = y;
+    }
+
+    function inner(Data memory data, uint256 _value, uint8 literal) internal returns(uint256) {
+        return ((a + data.c + b + data.d + _value) * literal * SOMETHING - SOMETHING_ELSE) / 1000;
+    }
+
+    function main(uint256 _value) external returns(uint256) {
+        Data memory data = Data({c: 10, d: 20});
+
+        return inner(data, _value, 42);
+    }
+}

--- a/solidity/simple/immutable_eravm/unaligned/simple_operator.sol
+++ b/solidity/simple/immutable_eravm/unaligned/simple_operator.sol
@@ -1,0 +1,45 @@
+//! { "targets": [ "eravm" ], "cases": [ {
+//!     "name": "main",
+//!     "inputs": [
+//!         {
+//!             "method": "#deployer",
+//!             "calldata": [
+//!                 "0x03",
+//!                 "0x05",
+//!                 "0x02"
+//!             ],
+//!             "expected": [
+//!                 "Test.address"
+//!             ]
+//!         },
+//!         {
+//!             "method": "main",
+//!             "calldata": [
+//!                 "12"
+//!             ]
+//!         }
+//!     ],
+//!     "expected": [
+//!         "42"
+//!     ]
+//! } ] }
+
+// SPDX-License-Identifier: MIT
+
+pragma solidity >=0.6.5;
+
+contract Test {
+    uint8 immutable field_1;
+    uint8 immutable field_2;
+    uint8 immutable field_3;
+
+    constructor(uint8 a, uint8 b, uint8 c) public {
+        field_1 = a;
+        field_2 = b;
+        field_3 = c;
+    }
+
+    function main(uint8 witness) external returns(uint8) {
+        return witness + field_1 * field_2 * field_3;
+    }
+}

--- a/solidity/simple/immutable_evm/aligned/complex_operator.sol
+++ b/solidity/simple/immutable_evm/aligned/complex_operator.sol
@@ -1,4 +1,4 @@
-//! { "cases": [ {
+//! { "targets": [ "evm" ], "cases": [ {
 //!     "name": "main",
 //!     "inputs": [
 //!         {
@@ -26,20 +26,20 @@
 
 // SPDX-License-Identifier: MIT
 
-pragma solidity >=0.6.5;
+pragma solidity >=0.8.0;
 
 contract Test {
-    uint8 immutable field_1;
-    uint8 immutable field_2;
-    uint8 immutable field_3;
+    uint256 immutable field_1;
+    uint256 immutable field_2;
+    uint256 immutable field_3;
 
-    constructor(uint8 a, uint8 b, uint8 c) public {
+    constructor(uint256 a, uint256 b, uint256 c) public {
         field_1 = a;
         field_2 = b;
         field_3 = c;
     }
 
     function main(uint8 witness) external returns(uint8) {
-        return 19 * 3 - 8 / field_1 + (witness / (field_2 - 3) + 5) * (8 / field_3 / 2);
+        return 19 * 3 - 8 / uint8(field_1) + (witness / (uint8(field_2) - 3) + 5) * (8 / uint8(field_3) / 2);
     }
 }

--- a/solidity/simple/immutable_evm/aligned/method_chain.sol
+++ b/solidity/simple/immutable_evm/aligned/method_chain.sol
@@ -1,11 +1,11 @@
-//! { "cases": [ {
+//! { "targets": [ "evm" ], "cases": [ {
 //!     "name": "main",
 //!     "inputs": [
 //!         {
 //!             "method": "#deployer",
 //!             "calldata": [
 //!                 "0x05",
-//!                 "0x07"
+//!                 "0x0b"
 //!             ],
 //!             "expected": [
 //!                 "Test.address"
@@ -19,23 +19,15 @@
 //!         }
 //!     ],
 //!     "expected": [
-//!         "148"
+//!         "1024"
 //!     ]
 //! } ] }
 
 // SPDX-License-Identifier: MIT
 
-pragma solidity >=0.6.5;
+pragma solidity >=0.8.0;
 
 contract Test {
-    uint256 constant SOMETHING = 42;
-    uint256 constant SOMETHING_ELSE = 88;
-
-    struct Data {
-        uint256 c;
-        uint256 d;
-    }
-
     uint256 immutable a;
     uint256 immutable b;
 
@@ -44,13 +36,19 @@ contract Test {
         b = y;
     }
 
-    function inner(Data memory data, uint256 _value, uint8 literal) internal returns(uint256) {
-        return ((a + data.c + b + data.d + _value) * literal * SOMETHING - SOMETHING_ELSE) / 1000;
+    function double(uint256 _value) internal returns(uint256) {
+        return _value * 2;
+    }
+
+    function triple(uint256 _value) internal returns(uint256) {
+        return 3 * _value;
+    }
+
+    function quadruple(uint256 _value) internal returns(uint256) {
+        return _value * 4;
     }
 
     function main(uint256 _value) external returns(uint256) {
-        Data memory data = Data({c: 10, d: 20});
-
-        return inner(data, _value, 42);
+        return a + quadruple(triple(double(_value))) + b;
     }
 }

--- a/solidity/simple/immutable_evm/aligned/mixed_data_origin.sol
+++ b/solidity/simple/immutable_evm/aligned/mixed_data_origin.sol
@@ -1,0 +1,56 @@
+//! { "targets": [ "evm" ], "cases": [ {
+//!     "name": "main",
+//!     "inputs": [
+//!         {
+//!             "method": "#deployer",
+//!             "calldata": [
+//!                 "0x05",
+//!                 "0x07"
+//!             ],
+//!             "expected": [
+//!                 "Test.address"
+//!             ]
+//!         },
+//!         {
+//!             "method": "main",
+//!             "calldata": [
+//!                 "42"
+//!             ]
+//!         }
+//!     ],
+//!     "expected": [
+//!         "148"
+//!     ]
+//! } ] }
+
+// SPDX-License-Identifier: MIT
+
+pragma solidity >=0.8.0;
+
+contract Test {
+    uint256 constant SOMETHING = 42;
+    uint256 constant SOMETHING_ELSE = 88;
+
+    struct Data {
+        uint256 c;
+        uint256 d;
+    }
+
+    uint256 immutable a;
+    uint256 immutable b;
+
+    constructor(uint256 x, uint256 y) public {
+        a = x;
+        b = y;
+    }
+
+    function inner(Data memory data, uint256 _value, uint8 literal) internal returns(uint256) {
+        return ((a + data.c + b + data.d + _value) * literal * SOMETHING - SOMETHING_ELSE) / 1000;
+    }
+
+    function main(uint256 _value) external returns(uint256) {
+        Data memory data = Data({c: 10, d: 20});
+
+        return inner(data, _value, 42);
+    }
+}

--- a/solidity/simple/immutable_evm/aligned/simple_operator.sol
+++ b/solidity/simple/immutable_evm/aligned/simple_operator.sol
@@ -1,0 +1,45 @@
+//! { "targets": [ "evm" ], "cases": [ {
+//!     "name": "main",
+//!     "inputs": [
+//!         {
+//!             "method": "#deployer",
+//!             "calldata": [
+//!                 "0x03",
+//!                 "0x05",
+//!                 "0x02"
+//!             ],
+//!             "expected": [
+//!                 "Test.address"
+//!             ]
+//!         },
+//!         {
+//!             "method": "main",
+//!             "calldata": [
+//!                 "12"
+//!             ]
+//!         }
+//!     ],
+//!     "expected": [
+//!         "42"
+//!     ]
+//! } ] }
+
+// SPDX-License-Identifier: MIT
+
+pragma solidity >=0.8.0;
+
+contract Test {
+    uint256 immutable field_1;
+    uint256 immutable field_2;
+    uint256 immutable field_3;
+
+    constructor(uint256 a, uint256 b, uint256 c) public {
+        field_1 = a;
+        field_2 = b;
+        field_3 = c;
+    }
+
+    function main(uint8 witness) external returns(uint8) {
+        return witness + uint8(field_1) * uint8(field_2) * uint8(field_3);
+    }
+}

--- a/solidity/simple/immutable_evm/constructor.sol
+++ b/solidity/simple/immutable_evm/constructor.sol
@@ -1,0 +1,49 @@
+//! { "targets": [ "evm" ], "cases": [ {
+//!     "name": "default",
+//!     "inputs": [
+//!         {
+//!             "method": "#deployer",
+//!             "caller": "0x0000000000000000000000000000000000000099",
+//!             "calldata": [
+//!                 "25", "42"
+//!             ],
+//!             "expected": [
+//!                 "Test.address"
+//!             ]
+//!         },
+//!         {
+//!             "method": "a",
+//!             "calldata": [],
+//!             "expected": [ "25" ]
+//!         },
+//!         {
+//!             "method": "b",
+//!             "calldata": [],
+//!             "expected": [ "0x99" ]
+//!         },
+//!         {
+//!             "method": "c",
+//!             "calldata": [],
+//!             "expected": [ "42" ]
+//!         }
+//!     ],
+//!     "expected": [ "42" ]
+//! } ] }
+
+// SPDX-License-Identifier: MIT
+
+// Report https://linear.app/matterlabs/issue/CPR-288/implement-the-setimmutable-and-loadimmutable-functions
+
+pragma solidity >=0.8.0;
+
+contract Test {
+    uint immutable public a;
+    address immutable public b;
+    uint8 immutable public c;
+
+    constructor(uint x, uint8 y) {
+        a = x;
+        b = msg.sender;
+        c = y;
+    }
+}

--- a/solidity/simple/immutable_evm/inheritance/immutables1.sol
+++ b/solidity/simple/immutable_evm/inheritance/immutables1.sol
@@ -1,0 +1,53 @@
+//! { "targets": [ "evm" ], "cases": [ {
+//!     "name": "test",
+//!     "inputs": [
+//!         {
+//!             "method": "f",
+//!             "calldata": [
+//!             ]
+//!         }
+//!     ],
+//!     "expected": [
+//!         "5", "6", "7"
+//!     ]
+//! } ] }
+
+// SPDX-License-Identifier: MIT
+
+pragma solidity >=0.8.20;
+
+contract TestC {
+    uint256 immutable z;
+
+    constructor() {
+        z = 7;
+    }
+
+    function fC() public returns (uint256) {
+        return z;
+    }
+}
+
+contract TestB is TestC {
+    uint256 immutable y;
+
+    constructor() {
+        y = 6;
+    }
+
+    function fB() public returns (uint256) {
+        return y;
+    }
+}
+
+contract Test is TestC, TestB {
+    uint256 immutable x;
+
+    constructor() {
+        x = 5;
+    }
+
+    function f() public returns (uint256, uint256, uint256) {
+        return (x, y, z);
+    }
+}

--- a/solidity/simple/immutable_evm/inheritance/immutables2.sol
+++ b/solidity/simple/immutable_evm/inheritance/immutables2.sol
@@ -1,0 +1,53 @@
+//! { "targets": [ "evm" ], "cases": [ {
+//!     "name": "test",
+//!     "inputs": [
+//!         {
+//!             "method": "f",
+//!             "calldata": [
+//!             ]
+//!         }
+//!     ],
+//!     "expected": [
+//!         "7", "6", "7"
+//!     ]
+//! } ] }
+
+// SPDX-License-Identifier: MIT
+
+pragma solidity >=0.8.20;
+
+contract TestC {
+    uint256 immutable z;
+
+    constructor() {
+        z = 7;
+    }
+
+    function fC() public returns (uint256) {
+        return z;
+    }
+}
+
+contract TestB is TestC {
+    uint256 immutable y;
+
+    constructor() {
+        y = 6;
+    }
+
+    function fB() public returns (uint256) {
+        return y;
+    }
+}
+
+contract Test is TestC, TestB {
+    uint256 immutable x;
+
+    constructor() {
+        x = fC();
+    }
+
+    function f() public returns (uint256, uint256, uint256) {
+        return (x, y, z);
+    }
+}

--- a/solidity/simple/immutable_evm/inheritance/immutables3.sol
+++ b/solidity/simple/immutable_evm/inheritance/immutables3.sol
@@ -1,18 +1,16 @@
-//! { "modes": [ "Y", "I" ], "cases": [{
+//! { "targets": [ "evm" ], "cases": [ {
 //!     "name": "test",
 //!     "inputs": [
 //!         {
 //!             "method": "f",
-//!             "calldata": []
+//!             "calldata": [
+//!             ]
 //!         }
 //!     ],
 //!     "expected": [
-//!         "0",
-//!         "8",
-//!         "0"
+//!         "5", "0", "7"
 //!     ]
-//!     }
-//! ]}
+//! } ] }
 
 // SPDX-License-Identifier: MIT
 
@@ -20,22 +18,21 @@ pragma solidity >=0.8.20;
 
 contract TestC {
     uint256 immutable z;
-    uint s = 8;
 
-    constructor(uint _val) {
-        z = _val;
+    constructor() {
+        z = 7;
     }
 
     function fC() public returns (uint256) {
-        return s;
+        return z;
     }
 }
 
 contract TestB is TestC {
     uint256 immutable y;
 
-    constructor(uint _val) TestC(_val) {
-        y = fC();
+    constructor(uint _val) {
+        y = _val;
     }
 
     function fB() public returns (uint256) {
@@ -47,7 +44,7 @@ contract Test is TestC, TestB {
     uint256 immutable x;
 
     constructor() TestB(fC()) {
-        x = z;
+        x = 5;
     }
 
     function f() public returns (uint256, uint256, uint256) {

--- a/solidity/simple/immutable_evm/inheritance/immutables4.sol
+++ b/solidity/simple/immutable_evm/inheritance/immutables4.sol
@@ -1,4 +1,4 @@
-//! { "cases": [ {
+//! { "targets": [ "evm" ], "cases": [ {
 //!     "name": "test",
 //!     "inputs": [
 //!         {
@@ -8,7 +8,7 @@
 //!         }
 //!     ],
 //!     "expected": [
-//!         "5", "6", "7"
+//!         "0", "0", "7"
 //!     ]
 //! } ] }
 
@@ -31,8 +31,8 @@ contract TestC {
 contract TestB is TestC {
     uint256 immutable y;
 
-    constructor() {
-        y = 6;
+    constructor(uint _val) {
+        y = _val;
     }
 
     function fB() public returns (uint256) {
@@ -43,8 +43,8 @@ contract TestB is TestC {
 contract Test is TestC, TestB {
     uint256 immutable x;
 
-    constructor() {
-        x = 5;
+    constructor() TestB(fB()) {
+        x = fB();
     }
 
     function f() public returns (uint256, uint256, uint256) {

--- a/solidity/simple/immutable_evm/inheritance/immutables5.sol
+++ b/solidity/simple/immutable_evm/inheritance/immutables5.sol
@@ -1,4 +1,4 @@
-//! { "cases": [ {
+//! { "targets": [ "evm" ], "cases": [ {
 //!     "name": "test",
 //!     "inputs": [
 //!         {

--- a/solidity/simple/immutable_evm/inheritance/immutables6_legacy.sol
+++ b/solidity/simple/immutable_evm/inheritance/immutables6_legacy.sol
@@ -1,0 +1,56 @@
+//! { "modes": [ "E" ], "targets": [ "evm" ], "cases": [{
+//!     "name": "test",
+//!     "inputs": [
+//!         {
+//!             "method": "f",
+//!             "calldata": []
+//!         }
+//!     ],
+//!     "expected": [
+//!         "8",
+//!         "8",
+//!         "8"
+//!     ]
+//!     }
+//! ]}
+
+// SPDX-License-Identifier: MIT
+
+pragma solidity >=0.8.20;
+
+contract TestC {
+    uint256 immutable z;
+    uint s = 8;
+
+    constructor(uint _val) {
+        z = _val;
+    }
+
+    function fC() public returns (uint256) {
+        return s;
+    }
+}
+
+contract TestB is TestC {
+    uint256 immutable y;
+
+    constructor(uint _val) TestC(_val) {
+        y = fC();
+    }
+
+    function fB() public returns (uint256) {
+        return y;
+    }
+}
+
+contract Test is TestC, TestB {
+    uint256 immutable x;
+
+    constructor() TestB(fC()) {
+        x = z;
+    }
+
+    function f() public returns (uint256, uint256, uint256) {
+        return (x, y, z);
+    }
+}

--- a/solidity/simple/immutable_evm/inheritance/immutables6_yul.sol
+++ b/solidity/simple/immutable_evm/inheritance/immutables6_yul.sol
@@ -1,16 +1,18 @@
-//! { "cases": [ {
+//! { "modes": [ "Y", "I" ], "targets": [ "evm" ], "cases": [{
 //!     "name": "test",
 //!     "inputs": [
 //!         {
 //!             "method": "f",
-//!             "calldata": [
-//!             ]
+//!             "calldata": []
 //!         }
 //!     ],
 //!     "expected": [
-//!         "5", "0", "7"
+//!         "0",
+//!         "8",
+//!         "0"
 //!     ]
-//! } ] }
+//!     }
+//! ]}
 
 // SPDX-License-Identifier: MIT
 
@@ -18,21 +20,22 @@ pragma solidity >=0.8.20;
 
 contract TestC {
     uint256 immutable z;
+    uint s = 8;
 
-    constructor() {
-        z = 7;
+    constructor(uint _val) {
+        z = _val;
     }
 
     function fC() public returns (uint256) {
-        return z;
+        return s;
     }
 }
 
 contract TestB is TestC {
     uint256 immutable y;
 
-    constructor(uint _val) {
-        y = _val;
+    constructor(uint _val) TestC(_val) {
+        y = fC();
     }
 
     function fB() public returns (uint256) {
@@ -44,7 +47,7 @@ contract Test is TestC, TestB {
     uint256 immutable x;
 
     constructor() TestB(fC()) {
-        x = 5;
+        x = z;
     }
 
     function f() public returns (uint256, uint256, uint256) {

--- a/solidity/simple/immutable_evm/memory_manipulation.sol
+++ b/solidity/simple/immutable_evm/memory_manipulation.sol
@@ -1,0 +1,36 @@
+//! { "modes": [
+//!     "Y", "E+ <=0.8.12", "E+ >=0.8.15", "E-", "I"
+//! ], "targets": [ "evm" ], "cases": [
+//!         {
+//!             "name": "main",
+//!             "inputs": [
+//!                 {
+//!                     "method": "main",
+//!                     "calldata": []
+//!                 }
+//!             ],
+//!             "expected": {
+//!                 "return_data": ["2"]
+//!             }
+//!         }
+//!     ]
+//! }
+
+// SPDX-License-Identifier: MIT
+
+pragma solidity >=0.8.0;
+
+contract Test {
+    uint256 public immutable X;
+
+    constructor() public {
+        X = 1;
+        assembly {
+            mstore(0x80, 2)
+        }
+    }
+
+    function main() public view returns (uint256) {
+        return X;
+    }
+}

--- a/solidity/simple/immutable_evm/trycatch.sol
+++ b/solidity/simple/immutable_evm/trycatch.sol
@@ -1,4 +1,4 @@
-//! { "cases": [ {
+//! { "targets": [ "evm" ], "cases": [ {
 //!     "name": "trycatch",
 //!     "inputs": [
 //!         {
@@ -12,7 +12,7 @@
 
 // SPDX-License-Identifier: MIT
 
-pragma solidity >=0.6.5 <=0.8.19;
+pragma solidity >=0.8.0 <=0.8.19;
 
 contract Test {
     uint256 public immutable Temp;

--- a/solidity/simple/immutable_evm/unaligned/complex_operator.sol
+++ b/solidity/simple/immutable_evm/unaligned/complex_operator.sol
@@ -1,0 +1,45 @@
+//! { "targets": [ "evm" ], "cases": [ {
+//!     "name": "main",
+//!     "inputs": [
+//!         {
+//!             "method": "#deployer",
+//!             "calldata": [
+//!                 "0x03",
+//!                 "0x05",
+//!                 "0x02"
+//!             ],
+//!             "expected": [
+//!                 "Test.address"
+//!             ]
+//!         },
+//!         {
+//!             "method": "main",
+//!             "calldata": [
+//!                 "16"
+//!             ]
+//!         }
+//!     ],
+//!     "expected": [
+//!         "81"
+//!     ]
+//! } ] }
+
+// SPDX-License-Identifier: MIT
+
+pragma solidity >=0.8.0;
+
+contract Test {
+    uint8 immutable field_1;
+    uint8 immutable field_2;
+    uint8 immutable field_3;
+
+    constructor(uint8 a, uint8 b, uint8 c) public {
+        field_1 = a;
+        field_2 = b;
+        field_3 = c;
+    }
+
+    function main(uint8 witness) external returns(uint8) {
+        return 19 * 3 - 8 / field_1 + (witness / (field_2 - 3) + 5) * (8 / field_3 / 2);
+    }
+}

--- a/solidity/simple/immutable_evm/unaligned/method_chain.sol
+++ b/solidity/simple/immutable_evm/unaligned/method_chain.sol
@@ -1,11 +1,11 @@
-//! { "cases": [ {
+//! { "targets": [ "evm" ], "cases": [ {
 //!     "name": "main",
 //!     "inputs": [
 //!         {
 //!             "method": "#deployer",
 //!             "calldata": [
 //!                 "0x05",
-//!                 "0x07"
+//!                 "0x0b"
 //!             ],
 //!             "expected": [
 //!                 "Test.address"
@@ -19,23 +19,15 @@
 //!         }
 //!     ],
 //!     "expected": [
-//!         "148"
+//!         "1024"
 //!     ]
 //! } ] }
 
 // SPDX-License-Identifier: MIT
 
-pragma solidity >=0.6.5;
+pragma solidity >=0.8.0;
 
 contract Test {
-    uint256 constant SOMETHING = 42;
-    uint256 constant SOMETHING_ELSE = 88;
-
-    struct Data {
-        uint256 c;
-        uint256 d;
-    }
-
     uint8 immutable a;
     uint8 immutable b;
 
@@ -44,13 +36,19 @@ contract Test {
         b = y;
     }
 
-    function inner(Data memory data, uint256 _value, uint8 literal) internal returns(uint256) {
-        return ((a + data.c + b + data.d + _value) * literal * SOMETHING - SOMETHING_ELSE) / 1000;
+    function double(uint256 _value) internal returns(uint256) {
+        return _value * 2;
+    }
+
+    function triple(uint256 _value) internal returns(uint256) {
+        return 3 * _value;
+    }
+
+    function quadruple(uint256 _value) internal returns(uint256) {
+        return _value * 4;
     }
 
     function main(uint256 _value) external returns(uint256) {
-        Data memory data = Data({c: 10, d: 20});
-
-        return inner(data, _value, 42);
+        return a + quadruple(triple(double(_value))) + b;
     }
 }

--- a/solidity/simple/immutable_evm/unaligned/mixed_data_origin.sol
+++ b/solidity/simple/immutable_evm/unaligned/mixed_data_origin.sol
@@ -1,11 +1,11 @@
-//! { "cases": [ {
+//! { "targets": [ "evm" ], "cases": [ {
 //!     "name": "main",
 //!     "inputs": [
 //!         {
 //!             "method": "#deployer",
 //!             "calldata": [
 //!                 "0x05",
-//!                 "0x0b"
+//!                 "0x07"
 //!             ],
 //!             "expected": [
 //!                 "Test.address"
@@ -19,15 +19,23 @@
 //!         }
 //!     ],
 //!     "expected": [
-//!         "1024"
+//!         "148"
 //!     ]
 //! } ] }
 
 // SPDX-License-Identifier: MIT
 
-pragma solidity >=0.6.5;
+pragma solidity >=0.8.0;
 
 contract Test {
+    uint256 constant SOMETHING = 42;
+    uint256 constant SOMETHING_ELSE = 88;
+
+    struct Data {
+        uint256 c;
+        uint256 d;
+    }
+
     uint8 immutable a;
     uint8 immutable b;
 
@@ -36,19 +44,13 @@ contract Test {
         b = y;
     }
 
-    function double(uint256 _value) internal returns(uint256) {
-        return _value * 2;
-    }
-
-    function triple(uint256 _value) internal returns(uint256) {
-        return 3 * _value;
-    }
-
-    function quadruple(uint256 _value) internal returns(uint256) {
-        return _value * 4;
+    function inner(Data memory data, uint256 _value, uint8 literal) internal returns(uint256) {
+        return ((a + data.c + b + data.d + _value) * literal * SOMETHING - SOMETHING_ELSE) / 1000;
     }
 
     function main(uint256 _value) external returns(uint256) {
-        return a + quadruple(triple(double(_value))) + b;
+        Data memory data = Data({c: 10, d: 20});
+
+        return inner(data, _value, 42);
     }
 }

--- a/solidity/simple/immutable_evm/unaligned/simple_operator.sol
+++ b/solidity/simple/immutable_evm/unaligned/simple_operator.sol
@@ -1,4 +1,4 @@
-//! { "cases": [ {
+//! { "targets": [ "evm" ], "cases": [ {
 //!     "name": "main",
 //!     "inputs": [
 //!         {
@@ -15,31 +15,31 @@
 //!         {
 //!             "method": "main",
 //!             "calldata": [
-//!                 "16"
+//!                 "12"
 //!             ]
 //!         }
 //!     ],
 //!     "expected": [
-//!         "81"
+//!         "42"
 //!     ]
 //! } ] }
 
 // SPDX-License-Identifier: MIT
 
-pragma solidity >=0.6.5;
+pragma solidity >=0.8.0;
 
 contract Test {
-    uint256 immutable field_1;
-    uint256 immutable field_2;
-    uint256 immutable field_3;
+    uint8 immutable field_1;
+    uint8 immutable field_2;
+    uint8 immutable field_3;
 
-    constructor(uint256 a, uint256 b, uint256 c) public {
+    constructor(uint8 a, uint8 b, uint8 c) public {
         field_1 = a;
         field_2 = b;
         field_3 = c;
     }
 
     function main(uint8 witness) external returns(uint8) {
-        return 19 * 3 - 8 / uint8(field_1) + (witness / (uint8(field_2) - 3) + 5) * (8 / uint8(field_3) / 2);
+        return witness + field_1 * field_2 * field_3;
     }
 }

--- a/solidity/simple/solidity_by_example/simple/immutable.sol
+++ b/solidity/simple/solidity_by_example/simple/immutable.sol
@@ -41,7 +41,8 @@
 //! } ] }
 
 // SPDX-License-Identifier: MIT
-pragma solidity >=0.7.0;
+
+pragma solidity >=0.8.0;
 
 contract Test {
     // coding convention to uppercase constant variables


### PR DESCRIPTION
Turns the tests for immutables of for solc <0.8, as we cannot yet translate their EVM assembly to LLVM IR.

## Checklist

<!-- Check your PR fulfills the following items. -->
<!-- For draft PRs check the boxes as you complete them. -->

- [x] PR title corresponds to the body of PR.
- [x] Documentation comments have been added / updated.
