### PR TITLE
fix(evm): run svg in Mz only

### DIFF
--- a/solidity/complex/parser/svg/test_evm.json
+++ b/solidity/complex/parser/svg/test_evm.json
@@ -1,4 +1,4 @@
-{ "targets": [ "evm" ], "cases": [ {
+{ "targets": [ "evm" ], "modes": [ "Mz" ], "cases": [ {
     "name": "default",
     "inputs": [],
     "expected": []


### PR DESCRIPTION
Runs `tests/solidity/complex/parser/svg` only in `Mz` mode.

The test is too big, so it is reasonable to use it for testing size optimizations.

## Checklist

<!-- Check your PR fulfills the following items. -->
<!-- For draft PRs check the boxes as you complete them. -->

- [x] PR title corresponds to the body of PR.
- [x] Documentation comments have been added / updated.
